### PR TITLE
Fix 16MB read-limit crash in getUserSessions

### DIFF
--- a/convex/paintingSessions.ts
+++ b/convex/paintingSessions.ts
@@ -237,33 +237,37 @@ export const getUserSessions = query({
     // Collect sessionIds associated with this user through ownership or contributions
     const sessionIdSet = new Set<Id<"paintingSessions">>();
 
-    // 1) Owned sessions
+    // 1) Owned sessions (indexed — avoids scanning every session doc,
+    // which blows the 16MB read limit because thumbnails are stored inline)
     const ownedSessions = await ctx.db
       .query("paintingSessions")
-      .filter((q) => q.eq(q.field("createdBy"), user._id))
+      .withIndex("by_creator", (q) => q.eq("createdBy", user._id))
       .order("desc")
       .collect();
     ownedSessions.forEach((s) => sessionIdSet.add(s._id));
 
-    // 2) Sessions with strokes by this user (via index)
+    // 2-4) Sessions contributed to. Stroke docs carry full point arrays, so
+    // reads must stay bounded: only the most recent contributions are
+    // considered. Older contributed-to sessions won't appear unless owned.
     const userStrokes = await ctx.db
       .query("strokes")
       .withIndex("by_user", (q) => q.eq("userId", user._id))
-      .collect();
+      .order("desc")
+      .take(300);
     userStrokes.forEach((st) => sessionIdSet.add(st.sessionId));
 
-    // 3) Sessions with uploaded images by this user (via index)
     const userUploads = await ctx.db
       .query("uploadedImages")
       .withIndex("by_user", (q) => q.eq("userId", user._id))
-      .collect();
+      .order("desc")
+      .take(200);
     userUploads.forEach((img) => sessionIdSet.add(img.sessionId));
 
-    // 4) Sessions with paint layers created by this user (via index)
     const userLayers = await ctx.db
       .query("paintLayers")
       .withIndex("by_user", (q) => q.eq("createdBy", user._id))
-      .collect();
+      .order("desc")
+      .take(200);
     userLayers.forEach((pl) => sessionIdSet.add(pl.sessionId));
 
     // Fetch session docs for all collected IDs

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -25,7 +25,7 @@ const schema = defineSchema({
     lastClearBatchId: v.optional(v.string()),
     // AI generation prompts history
     aiPrompts: v.optional(v.array(v.string())), // Array of unique prompts used in this session
-  }),
+  }).index("by_creator", ["createdBy"]),
 
   strokes: defineTable({
     sessionId: v.id("paintingSessions"),


### PR DESCRIPTION
## Summary

Signing in crashed the library view with `Too many bytes read in a single function execution (limit: 16777216 bytes)` from `paintingSessions:getUserSessions`.

Two unbounded reads caused it:
1. **Full table scan** — owned sessions were found via `.filter()` with no index, reading every session doc in the deployment (session docs store thumbnails inline)
2. **Unbounded stroke collect** — every stroke the user ever painted was read in full (stroke docs carry complete point arrays; the strokes table is ~19MB)

## Fix

- New `by_creator` index on `paintingSessions`, queried with `withIndex`
- Contribution discovery (sessions you drew in but don't own) bounded to the most recent 300 strokes / 200 uploads / 200 paint layers

Behavior change: sessions you contributed to long ago (beyond those windows) no longer appear in the library unless you own them. A proper fix (a session-membership table) can come with the Phase 5 refactor.

## Test plan

- [x] typecheck clean; deployed to local self-hosted instance, index builds
- [x] Deployed to production (Mac mini), sign-in verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)