### PR TITLE
Require session authorization for P2P WebRTC signaling

### DIFF
--- a/convex/webrtc.ts
+++ b/convex/webrtc.ts
@@ -1,5 +1,36 @@
-import { mutation, query, internalMutation } from "./_generated/server";
+import { mutation, query, internalMutation, type MutationCtx, type QueryCtx } from "./_generated/server";
 import { v } from "convex/values";
+import { Id } from "./_generated/dataModel";
+
+/**
+ * Authorization: allow if public or owner or guest owner.
+ * Same pattern as strokes.addStroke / images.getSessionImages.
+ */
+async function assertSessionAccess(
+  ctx: MutationCtx | QueryCtx,
+  sessionId: Id<"paintingSessions">,
+  guestKey: string | undefined
+) {
+  const session = await ctx.db.get(sessionId);
+  if (!session) {
+    throw new Error("Session not found");
+  }
+  if (!session.isPublic) {
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity) {
+      const user = await ctx.db
+        .query("users")
+        .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+        .first();
+      if (!user || session.createdBy !== user._id) {
+        if (!session.guestOwnerKey || session.guestOwnerKey !== guestKey) throw new Error("Unauthorized");
+      }
+    } else {
+      if (!session.guestOwnerKey || session.guestOwnerKey !== guestKey) throw new Error("Unauthorized");
+    }
+  }
+  return session;
+}
 
 /**
  * Join a P2P session and get list of current peers
@@ -8,22 +39,16 @@ export const joinP2PSession = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
     peerId: v.string(), // Client-generated peer ID
-    roomKey: v.string(), // Room authentication key
+    roomKey: v.optional(v.string()), // Deprecated: kept so older clients don't fail arg validation
+    guestKey: v.optional(v.string()),
   },
   returns: v.object({
     peers: v.array(v.string()),
     mode: v.union(v.literal("mesh"), v.literal("sfu")),
   }),
   handler: async (ctx, args) => {
-    // Verify session exists
-    const session = await ctx.db.get(args.sessionId);
-    if (!session) {
-      throw new Error("Session not found");
-    }
-    
-    // TODO: Verify room key matches session
-    // For now, we'll skip authentication
-    
+    await assertSessionAccess(ctx, args.sessionId, args.guestKey);
+
     // Get active peers from presence data
     const thirtySecondsAgo = Date.now() - 30 * 1000;
     const activePeers = await ctx.db
@@ -76,9 +101,12 @@ export const sendSignal = mutation({
     toPeerId: v.string(),
     type: v.union(v.literal("offer"), v.literal("answer"), v.literal("ice-candidate")),
     data: v.any(), // SDP or ICE candidate data
+    guestKey: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
+    await assertSessionAccess(ctx, args.sessionId, args.guestKey);
+
     // Store signal in database
     await ctx.db.insert("webrtcSignals", {
       sessionId: args.sessionId,
@@ -100,6 +128,7 @@ export const getSignals = query({
   args: {
     sessionId: v.id("paintingSessions"),
     peerId: v.string(),
+    guestKey: v.optional(v.string()),
   },
   returns: v.array(v.object({
     id: v.id("webrtcSignals"),
@@ -108,6 +137,8 @@ export const getSignals = query({
     data: v.any(),
   })),
   handler: async (ctx, args) => {
+    await assertSessionAccess(ctx, args.sessionId, args.guestKey);
+
     // Get signals for this peer
     const signals = await ctx.db
       .query("webrtcSignals")

--- a/src/hooks/useP2PPainting.ts
+++ b/src/hooks/useP2PPainting.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { useConvex } from "convex/react";
 import { Id } from "../../convex/_generated/dataModel";
 import { P2PManager } from '../lib/webrtc/P2PManager';
+import { getGuestKey } from '../utils/guestKey';
 import type { 
   PreviewPacket, 
   CursorPacket,
@@ -134,12 +135,10 @@ export function useP2PPainting({
       return;
     }
 
-    const roomKey = `session-${sessionId}`; // Simple room key for now
-
     const manager = new P2PManager({
       sessionId,
       peerId: userId,
-      roomKey,
+      guestKey: getGuestKey(sessionId) || undefined,
       convexClient: convex,
       onPacketReceived: handlePacketReceived,
       onPeerConnected: handlePeerConnected,

--- a/src/lib/webrtc/P2PManager.ts
+++ b/src/lib/webrtc/P2PManager.ts
@@ -17,7 +17,7 @@ import { p2pLogger } from '../p2p-logger';
 export interface P2PManagerOptions {
   sessionId: Id<"paintingSessions">;
   peerId: string;
-  roomKey: string;
+  guestKey?: string; // Session guest-owner key for authorization on private sessions
   convexClient: ConvexReactClient;
   onPacketReceived?: (peerId: string, packet: P2PPacket) => void;
   onPeerConnected?: (peerId: string) => void;
@@ -32,7 +32,7 @@ export class P2PManager {
   private convexClient: ConvexReactClient;
   private sessionId: Id<"paintingSessions">;
   private peerId: string;
-  private roomKey: string;
+  private guestKey?: string;
   private pollingInterval: NodeJS.Timeout | null = null;
   private metrics: P2PMetrics = {
     latency: 0,
@@ -53,7 +53,7 @@ export class P2PManager {
     this.convexClient = options.convexClient;
     this.sessionId = options.sessionId;
     this.peerId = options.peerId;
-    this.roomKey = options.roomKey;
+    this.guestKey = options.guestKey;
     this.onPacketReceived = options.onPacketReceived;
     this.onPeerConnected = options.onPeerConnected;
     this.onPeerDisconnected = options.onPeerDisconnected;
@@ -75,7 +75,7 @@ export class P2PManager {
         {
           sessionId: this.sessionId,
           peerId: this.peerId,
-          roomKey: this.roomKey,
+          guestKey: this.guestKey,
         }
       );
 
@@ -220,6 +220,7 @@ export class P2PManager {
       toPeerId,
       type,
       data,
+      guestKey: this.guestKey,
     });
   }
 
@@ -232,6 +233,7 @@ export class P2PManager {
         const signals = await this.convexClient.query(api.webrtc.getSignals, {
           sessionId: this.sessionId,
           peerId: this.peerId,
+          guestKey: this.guestKey,
         });
 
         if (signals.length > 0) {


### PR DESCRIPTION
## Summary

Fixes the security gap flagged by the `TODO: Verify room key matches session` in `convex/webrtc.ts`. The P2P signaling endpoints (`joinP2PSession`, `sendSignal`, `getSignals`) accepted any caller who knew the session ID — the `roomKey` was just `session-${sessionId}`, derivable from the public session URL, so any URL holder could join P2P signaling even for private sessions.

## Changes

- **convex/webrtc.ts**: New `assertSessionAccess` helper replicating the ownership pattern used by `strokes.addStroke` and `images.getSessionImages`: public sessions are open; private sessions require the authenticated Clerk owner (`session.createdBy === user._id`) or the `guestOwnerKey`. Applied to `joinP2PSession`, `sendSignal`, and `getSignals` (throws "Unauthorized" / "Session not found").
- **src/lib/webrtc/P2PManager.ts**: Replaces the meaningless `roomKey` option with an optional `guestKey`, threaded through the join mutation, signal sends, and the signal polling query.
- **src/hooks/useP2PPainting.ts**: Passes the session's stored guest key from localStorage (`getGuestKey`) instead of deriving `session-${sessionId}`.

The `roomKey` arg is kept on `joinP2PSession` as a deprecated `v.optional` so already-deployed clients don't fail Convex argument validation during rollout; it is ignored.

## Testing

- `pnpm typecheck` passes (app + convex).
- No deploy performed — Mac mini production deploy is handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)