### PR TITLE
Add authorization to leaveP2PSession and deleteSignals

### DIFF
--- a/convex/webrtc.ts
+++ b/convex/webrtc.ts
@@ -166,19 +166,19 @@ export const getSignals = query({
 export const deleteSignals = mutation({
   args: {
     signalIds: v.array(v.id("webrtcSignals")),
+    sessionId: v.id("paintingSessions"),
+    peerId: v.string(),
+    guestKey: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
+    await assertSessionAccess(ctx, args.sessionId, args.guestKey);
+
     for (const id of args.signalIds) {
-      try {
-        // Check if document exists before deleting
-        const doc = await ctx.db.get(id);
-        if (doc) {
-          await ctx.db.delete(id);
-        }
-      } catch (error) {
-        // Ignore errors for non-existent documents
-        console.log(`Signal ${id} already deleted or doesn't exist`);
+      const doc = await ctx.db.get(id);
+      // Only delete signals in this session that were addressed to the caller
+      if (doc && doc.sessionId === args.sessionId && doc.toPeerId === args.peerId) {
+        await ctx.db.delete(id);
       }
     }
     return null;
@@ -192,9 +192,12 @@ export const leaveP2PSession = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
     peerId: v.string(),
+    guestKey: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
+    await assertSessionAccess(ctx, args.sessionId, args.guestKey);
+
     // Clean up any pending signals for this peer
     const signalsTo = await ctx.db
       .query("webrtcSignals")

--- a/src/lib/webrtc/P2PManager.ts
+++ b/src/lib/webrtc/P2PManager.ts
@@ -247,6 +247,9 @@ export class P2PManager {
           const signalIds = signals.map(s => s.id);
           await this.convexClient.mutation(api.webrtc.deleteSignals, {
             signalIds,
+            sessionId: this.sessionId,
+            peerId: this.peerId,
+            guestKey: this.guestKey,
           });
         }
       } catch (error) {
@@ -393,6 +396,7 @@ export class P2PManager {
       await this.convexClient.mutation(api.webrtc.leaveP2PSession, {
         sessionId: this.sessionId,
         peerId: this.peerId,
+        guestKey: this.guestKey,
       });
     } catch (error) {
       console.error('Error leaving P2P session:', error);


### PR DESCRIPTION
## What changed

PR #42 added session authorization (`assertSessionAccess`) to `joinP2PSession`, `sendSignal`, and `getSignals`, but left the two cleanup mutations in `convex/webrtc.ts` unauthenticated:

- **`leaveP2PSession`** let any caller delete all pending WebRTC signals to/from any peer in any session (minor signaling DoS). It now takes an optional `guestKey` and runs `assertSessionAccess` first.
- **`deleteSignals`** deleted arbitrary `webrtcSignals` docs by ID. It now requires `sessionId` and `peerId` (plus optional `guestKey`), runs `assertSessionAccess`, and only deletes signals that belong to that session **and** are addressed to the caller's `peerId` — so even an authorized session member can't delete signals meant for other peers.

`src/lib/webrtc/P2PManager.ts` threads `sessionId`/`peerId`/`guestKey` through both call sites (the manager already stores `guestKey` from #42). These are the only two callers in the repo.

## Notes for reviewers

- **This branch includes PR #42's commits** (merged from `claude/laughing-engelbart-076c1c`) since it builds directly on the `assertSessionAccess` helper. Merge #42 first and this PR reduces to the two-file diff above — or merge this one and close #42.
- `deleteSignals` gained required args, so a client running an old bundle during deploy would fail arg validation on that call. This is benign: the polling loop catches and logs the error, and stale signals expire via the `cleanupOldSignals` cron within a minute.
- `pnpm typecheck` (app + convex) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)