### PR TITLE
Add authorization to destructive stroke mutations

### DIFF
--- a/convex/liveStrokes.ts
+++ b/convex/liveStrokes.ts
@@ -1,5 +1,6 @@
 import { mutation, query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
+import { assertCanModifySession } from "./strokes";
 
 /**
  * Update or create a live stroke for a user
@@ -170,9 +171,17 @@ export const cleanupStaleLiveStrokes = internalMutation({
 export const clearSessionLiveStrokes = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
+    guestKey: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
+    const session = await ctx.db.get(args.sessionId);
+    if (!session) {
+      throw new Error("Session not found");
+    }
+    // Paired with strokes.clearSession — owner-only, even on public sessions
+    await assertCanModifySession(ctx, session, args.guestKey, { ownerOnly: true });
+
     const liveStrokes = await ctx.db
       .query("liveStrokes")
       .withIndex("by_session", (q) => q.eq("sessionId", args.sessionId))

--- a/convex/paintingSessions.ts
+++ b/convex/paintingSessions.ts
@@ -1,6 +1,6 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { Id } from "./_generated/dataModel";
+import { Doc, Id } from "./_generated/dataModel";
 import { createUserWithWelcomeTokens } from "./users";
 
 /**
@@ -83,6 +83,16 @@ export const createSession = mutation({
 });
 
 /**
+ * Strip guestOwnerKey before returning session docs to clients — exposing the
+ * key would let any viewer impersonate the guest owner. Clients only need to
+ * know whether a guest owner exists.
+ */
+function sanitizeSession(session: Doc<"paintingSessions">) {
+  const { guestOwnerKey, ...rest } = session;
+  return { ...rest, hasGuestOwner: !!guestOwnerKey };
+}
+
+/**
  * Get session details
  */
 export const getSession = query({
@@ -96,7 +106,7 @@ export const getSession = query({
       _creationTime: v.number(),
       name: v.optional(v.string()),
       createdBy: v.optional(v.id("users")),
-      guestOwnerKey: v.optional(v.string()),
+      hasGuestOwner: v.boolean(),
       isPublic: v.boolean(),
       canvasWidth: v.number(),
       canvasHeight: v.number(),
@@ -120,7 +130,7 @@ export const getSession = query({
     const session = await ctx.db.get(args.sessionId);
     if (!session) return null;
 
-    if (session.isPublic) return session;
+    if (session.isPublic) return sanitizeSession(session);
 
     // Private: only owner can view
     const identity = await ctx.auth.getUserIdentity();
@@ -129,12 +139,12 @@ export const getSession = query({
         .query("users")
         .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
         .first();
-      if (user && session.createdBy === user._id) return session;
+      if (user && session.createdBy === user._id) return sanitizeSession(session);
     }
 
     // Guest ownership
     if (session.guestOwnerKey && args.guestKey && session.guestOwnerKey === args.guestKey) {
-      return session;
+      return sanitizeSession(session);
     }
     return null;
   },
@@ -150,7 +160,7 @@ export const listRecentSessions = query({
     _creationTime: v.number(),
     name: v.optional(v.string()),
     createdBy: v.optional(v.id("users")),
-    guestOwnerKey: v.optional(v.string()),
+    hasGuestOwner: v.boolean(),
     isPublic: v.boolean(),
     canvasWidth: v.number(),
     canvasHeight: v.number(),
@@ -169,11 +179,12 @@ export const listRecentSessions = query({
     aiPrompts: v.optional(v.array(v.string())),
   })),
   handler: async (ctx) => {
-    return await ctx.db
+    const sessions = await ctx.db
       .query("paintingSessions")
       .filter((q) => q.eq(q.field("isPublic"), true))
       .order("desc")
       .take(20);
+    return sessions.map(sanitizeSession);
   },
 });
 
@@ -187,7 +198,7 @@ export const getUserSessions = query({
     _creationTime: v.number(),
     name: v.optional(v.string()),
     createdBy: v.optional(v.id("users")),
-    guestOwnerKey: v.optional(v.string()),
+    hasGuestOwner: v.boolean(),
     isPublic: v.boolean(),
     canvasWidth: v.number(),
     canvasHeight: v.number(),
@@ -258,28 +269,7 @@ export const getUserSessions = query({
     userLayers.forEach((pl) => sessionIdSet.add(pl.sessionId));
 
     // Fetch session docs for all collected IDs
-  const sessions: Array<{
-      _id: Id<"paintingSessions">;
-      _creationTime: number;
-      name?: string | undefined;
-      createdBy?: Id<"users"> | undefined;
-      isPublic: boolean;
-      canvasWidth: number;
-      canvasHeight: number;
-      strokeCounter: number;
-      paintLayerOrder?: number | undefined;
-      paintLayerVisible?: boolean | undefined;
-      backgroundImage?: string | undefined;
-      thumbnailUrl?: string | undefined;
-      lastModified?: number | undefined;
-      recentStrokeOrders?: number[] | undefined;
-      recentStrokeIds?: Id<"strokes">[] | undefined;
-      deletedStrokeCount?: number | undefined;
-      lastDeletedStrokeOrder?: number | undefined;
-      lastAction?: string | undefined;
-      lastClearBatchId?: string | undefined;
-      aiPrompts?: string[] | undefined;
-    }> = [];
+    const sessions: Array<Doc<"paintingSessions">> = [];
 
     for (const sessionId of sessionIdSet) {
       const session = await ctx.db.get(sessionId);
@@ -293,7 +283,7 @@ export const getUserSessions = query({
       return tb - ta;
     });
 
-    return sessions;
+    return sessions.map(sanitizeSession);
   },
 });
 

--- a/convex/strokes.ts
+++ b/convex/strokes.ts
@@ -1,5 +1,30 @@
-import { mutation, query } from "./_generated/server";
+import { mutation, query, QueryCtx } from "./_generated/server";
+import { Doc } from "./_generated/dataModel";
 import { v } from "convex/values";
+
+/**
+ * Authorization for session-modifying mutations.
+ * Allows: public sessions (unless ownerOnly), the signed-in owner, or the
+ * guest owner (matching guestOwnerKey). Throws "Unauthorized" otherwise.
+ */
+export async function assertCanModifySession(
+  ctx: QueryCtx,
+  session: Doc<"paintingSessions">,
+  guestKey: string | undefined,
+  opts?: { ownerOnly?: boolean },
+): Promise<void> {
+  if (session.isPublic && !opts?.ownerOnly) return;
+  const identity = await ctx.auth.getUserIdentity();
+  if (identity) {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
+      .first();
+    if (user && session.createdBy === user._id) return;
+  }
+  if (session.guestOwnerKey && guestKey && session.guestOwnerKey === guestKey) return;
+  throw new Error("Unauthorized");
+}
 
 /**
  * Add a new stroke to a painting session
@@ -31,21 +56,7 @@ export const addStroke = mutation({
     }
 
     // Authorization: allow if public or owner or guest owner
-    if (!session.isPublic) {
-      const identity = await ctx.auth.getUserIdentity();
-      if (identity) {
-        const user = await ctx.db
-          .query("users")
-          .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
-          .first();
-        if (!user || session.createdBy !== user._id) {
-          // Fall through to guest key check
-          if (!session.guestOwnerKey || session.guestOwnerKey !== args.guestKey) throw new Error("Unauthorized");
-        }
-      } else {
-        if (!session.guestOwnerKey || session.guestOwnerKey !== args.guestKey) throw new Error("Unauthorized");
-      }
-    }
+    await assertCanModifySession(ctx, session, args.guestKey);
 
     // Increment stroke counter for ordering
     const strokeOrder = session.strokeCounter + 1;
@@ -292,6 +303,7 @@ export const getStrokesAfter = query({
 export const removeLastStroke = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
+    guestKey: v.optional(v.string()),
   },
   returns: v.boolean(),
   handler: async (ctx, args) => {
@@ -300,6 +312,8 @@ export const removeLastStroke = mutation({
     if (!session) {
       throw new Error("Session not found");
     }
+
+    await assertCanModifySession(ctx, session, args.guestKey);
 
     // If the last action was a bulk clear and there are no strokes, treat Undo as restore-all
     if (session.lastAction === 'clear' && session.lastClearBatchId) {
@@ -441,6 +455,7 @@ export const removeLastStroke = mutation({
 export const restoreLastDeletedStroke = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
+    guestKey: v.optional(v.string()),
   },
   returns: v.boolean(),
   handler: async (ctx, args) => {
@@ -449,6 +464,8 @@ export const restoreLastDeletedStroke = mutation({
     if (!session) {
       throw new Error("Session not found");
     }
+
+    await assertCanModifySession(ctx, session, args.guestKey);
 
     let lastDeletedStroke = null;
     
@@ -533,6 +550,7 @@ export const restoreLastDeletedStroke = mutation({
 export const deleteStroke = mutation({
   args: {
     strokeId: v.id("strokes"),
+    guestKey: v.optional(v.string()),
   },
   returns: v.boolean(),
   handler: async (ctx, args) => {
@@ -541,6 +559,13 @@ export const deleteStroke = mutation({
     if (!stroke) {
       return false; // Stroke not found
     }
+
+    const session = await ctx.db.get(stroke.sessionId);
+    if (!session) {
+      throw new Error("Session not found");
+    }
+    // Deleting arbitrary strokes is owner-only, even on public sessions
+    await assertCanModifySession(ctx, session, args.guestKey, { ownerOnly: true });
 
     // Save the stroke to deletedStrokes before deleting
     await ctx.db.insert("deletedStrokes", {
@@ -571,6 +596,7 @@ export const deleteStroke = mutation({
 export const clearSession = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
+    guestKey: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -579,6 +605,9 @@ export const clearSession = mutation({
     if (!session) {
       throw new Error("Session not found");
     }
+
+    // Clearing the whole canvas is owner-only, even on public sessions
+    await assertCanModifySession(ctx, session, args.guestKey, { ownerOnly: true });
 
     // Get all strokes for this session
     const strokes = await ctx.db

--- a/src/hooks/usePaintingSession.ts
+++ b/src/hooks/usePaintingSession.ts
@@ -82,11 +82,9 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
   // Guest key state (in-memory) to ensure we always pass it on initial queries
   const [guestKeyState, setGuestKeyState] = useState<string | null>(null);
   useEffect(() => {
-    if (sessionId && !guestKeyState) {
-      const existing = getGuestKey(sessionId as any);
-      if (existing) setGuestKeyState(existing);
-    }
-  }, [sessionId, guestKeyState]);
+    // Re-read on session change so a stale key from a previous session is never sent
+    setGuestKeyState(getGuestKey(sessionId as any));
+  }, [sessionId]);
 
   // Queries
   const localGuestKey = guestKeyState || getGuestKey(sessionId as any);
@@ -167,7 +165,7 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
     if (!session) return;
     if (session.createdBy !== undefined) return;
     // Avoid claiming sessions that have a guest owner key
-    if ((session as any).guestOwnerKey) return;
+    if (session.hasGuestOwner) return;
     claimSessionOwnership({ sessionId });
   }, [sessionId, authenticatedUser, session, claimSessionOwnership]);
 
@@ -337,8 +335,8 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
     
     // Clear both completed strokes and live strokes
     await Promise.all([
-      clearSessionMutation({ sessionId }),
-      clearSessionLiveStrokes({ sessionId })
+      clearSessionMutation({ sessionId, guestKey: localGuestKey || undefined }),
+      clearSessionLiveStrokes({ sessionId, guestKey: localGuestKey || undefined })
     ]);
     
     // Reset local acknowledgment state
@@ -352,21 +350,21 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
         lastAckedStrokeOrder: 0,
       });
     }
-  }, [sessionId, clearSessionMutation, clearSessionLiveStrokes, currentUser.id, upsertViewerState]);
+  }, [sessionId, clearSessionMutation, clearSessionLiveStrokes, currentUser.id, upsertViewerState, localGuestKey]);
 
   // Undo the last stroke
   const undoLastStroke = useCallback(async () => {
     if (!sessionId) return false;
     
-    return await removeLastStroke({ sessionId });
-  }, [sessionId, removeLastStroke]);
+    return await removeLastStroke({ sessionId, guestKey: localGuestKey || undefined });
+  }, [sessionId, removeLastStroke, localGuestKey]);
 
   // Redo the last undone stroke
   const redoLastStroke = useCallback(async () => {
     if (!sessionId) return false;
     
-    return await restoreLastDeletedStroke({ sessionId });
-  }, [sessionId, restoreLastDeletedStroke]);
+    return await restoreLastDeletedStroke({ sessionId, guestKey: localGuestKey || undefined });
+  }, [sessionId, restoreLastDeletedStroke, localGuestKey]);
 
   // Throttle live stroke updates to reduce lag
   const liveStrokeUpdateRef = useRef<NodeJS.Timeout | null>(null);


### PR DESCRIPTION
## What

Priority 1 (C2) from the UX/security audit: `clearSession`, `removeLastStroke`, `restoreLastDeletedStroke`, and `deleteStroke` in `convex/strokes.ts` only checked that the session existed — any stranger with a session ID could wipe any painting, including private ones. `clearSessionLiveStrokes` in `convex/liveStrokes.ts` had the same hole and is part of the same clear flow.

## Changes

- New exported `assertCanModifySession(ctx, session, guestKey, {ownerOnly?})` helper in `convex/strokes.ts`: public sessions allowed (unless `ownerOnly`), otherwise signed-in owner or matching `guestOwnerKey`, otherwise throws `Unauthorized`. `addStroke`'s inline auth block now uses it too, so the rule lives in one place.
- `removeLastStroke` / `restoreLastDeletedStroke`: same rule as `addStroke` — visitors to public sessions can still undo/redo, matching their draw permission.
- `clearSession`, `deleteStroke`, `clearSessionLiveStrokes`: **owner-only even on public sessions.** Clearing the whole canvas or deleting arbitrary strokes is too destructive for visitors (`deleteStroke` has no frontend callers, so the strict rule is free).
- **Key-leak fix found during review:** `getSession`, `listRecentSessions`, and `getUserSessions` returned `guestOwnerKey` to any viewer, which would let anyone impersonate the guest owner and defeat all of the above. Session queries now return a `hasGuestOwner` boolean instead; the only frontend consumer needed just the truthiness check.
- Frontend (`src/hooks/usePaintingSession.ts`): threads `guestKey` into clear/undo/redo mutation calls; cached guest-key state resets on `sessionId` change so a stale key from a previous session is never sent.

## Verification

- `pnpm typecheck` passes.
- Exercised the full matrix against a local Convex backend via `convex run`:
  - Private guest session: owner key can add/undo/redo/clear; a stranger gets `Unauthorized` for all of them.
  - Public session: a stranger can still add, undo, and redo strokes, but gets `Unauthorized` for `clearSession`, `clearSessionLiveStrokes`, and `deleteStroke`; the owner key succeeds on all.
  - `getSession` output contains `hasGuestOwner` and no `guestOwnerKey`.
- Signed-in-owner path not exercised live (needs OAuth) but is the identical identity-lookup logic `addStroke` already used in production, unchanged.

## Reviewer notes

- Behavior change: a non-owner visitor on a public session who clicks Clear now gets a rejected mutation; `PaintingView.handleClear` catches it and the live query re-syncs the canvas, so no crash — but the button is still visible to them.
- Known accepted semantic: on a public session, a visitor's undo right after an owner's clear restores the cleared batch (existing undo-of-clear behavior; restore, not destroy).
- Remaining lower-severity gap (follow-up task spawned): `updateLiveStroke` / `clearLiveStroke` are still unauthenticated (ephemeral preview data only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)