### PR TITLE
Surface actionable errors in AI modals; share-link copy feedback

### DIFF
--- a/src/components/AIGenerationModal.tsx
+++ b/src/components/AIGenerationModal.tsx
@@ -4,6 +4,7 @@ import { useAction, useQuery, useMutation } from 'convex/react'
 import { api } from '../../convex/_generated/api'
 import type { Id } from '../../convex/_generated/dataModel'
 import { getGuestKey } from '../utils/guestKey'
+import { getErrorMessage } from '../utils/errorMessage'
 
 interface AIGenerationModalProps {
   isOpen: boolean
@@ -89,7 +90,7 @@ export function AIGenerationModal({
         setError(('error' in result && result.error) || 'Generation failed')
       }
     } catch (err) {
-      setError('Failed to generate image. Please try again.')
+      setError(getErrorMessage(err, 'Failed to generate image. Please try again.'))
       console.error('AI generation error:', err)
     } finally {
       setIsGenerating(false)

--- a/src/components/BackgroundRemovalModal.tsx
+++ b/src/components/BackgroundRemovalModal.tsx
@@ -4,6 +4,7 @@ import { useAction, useQuery } from 'convex/react'
 import { api } from '../../convex/_generated/api'
 import type { Id } from '../../convex/_generated/dataModel'
 import type { Layer } from './ToolPanel'
+import { getErrorMessage } from '../utils/errorMessage'
 
 interface BackgroundRemovalModalProps {
   isOpen: boolean
@@ -94,7 +95,7 @@ export function BackgroundRemovalModal({
         setError('Background removal failed')
       }
     } catch (err) {
-      setError('Failed to remove background. Please try again.')
+      setError(getErrorMessage(err, 'Failed to remove background. Please try again.'))
       console.error('Background removal error:', err)
     } finally {
       setIsRemoving(false)

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { X, Copy, Globe, Lock } from 'lucide-react'
+import React, { useRef, useState } from 'react'
+import { X, Copy, Check, Globe, Lock } from 'lucide-react'
 import { useQuery, useMutation } from 'convex/react'
 import { api } from '../../convex/_generated/api'
 import { Id } from '../../convex/_generated/dataModel'
@@ -16,11 +16,27 @@ export function ShareModal({ isOpen, onClose, sessionId }: ShareModalProps) {
   const session = useQuery(api.paintingSessions.getSession, { sessionId, guestKey: localGuestKey || undefined })
   const setVisibility = useMutation(api.paintingSessions.setSessionVisibility)
   const currentUser = useQuery(api.auth.getCurrentUser)
+  const [copied, setCopied] = useState(false)
+  const linkInputRef = useRef<HTMLInputElement>(null)
 
   if (!isOpen) return null
 
   const isOwner = (session && currentUser && session.createdBy === currentUser._id) || !!localGuestKey
   const shareUrl = `${window.location.origin}?session=${sessionId}`
+  const isPublic = !!session?.isPublic
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(shareUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error('Failed to copy link', err)
+      // Clipboard unavailable — select the text so the user can copy manually
+      linkInputRef.current?.focus()
+      linkInputRef.current?.select()
+    }
+  }
 
   return (
     <div className="fixed inset-0 z-[110] flex items-center justify-center">
@@ -40,30 +56,46 @@ export function ShareModal({ isOpen, onClose, sessionId }: ShareModalProps) {
             <label className="text-xs text-white/60">Session link</label>
             <div className="mt-1 flex items-center gap-2">
               <input
+                ref={linkInputRef}
                 readOnly
                 value={shareUrl}
+                onFocus={(e) => e.target.select()}
                 className="flex-1 bg-white/10 border border-white/20 rounded px-2 py-1 text-sm text-white"
               />
               <button
                 className="px-2 py-1 bg-white/10 hover:bg-white/20 border border-white/20 rounded text-sm text-white flex items-center gap-1"
-                onClick={async () => {
-                  await navigator.clipboard.writeText(shareUrl)
-                }}
+                onClick={handleCopy}
               >
-                <Copy className="w-3.5 h-3.5" /> Copy
+                {copied ? (
+                  <>
+                    <Check className="w-3.5 h-3.5 text-green-400" /> Copied
+                  </>
+                ) : (
+                  <>
+                    <Copy className="w-3.5 h-3.5" /> Copy
+                  </>
+                )}
               </button>
             </div>
+            {copied && !isPublic && (
+              <div className="mt-2 text-xs text-yellow-300/80">
+                This session is private — recipients won't be able to open the link until you turn on Public access.
+              </div>
+            )}
           </div>
           <div className="flex items-center justify-between">
             <div>
               <div className="text-sm text-white/80">Public access</div>
               <div className="text-xs text-white/50">Allow anyone with the link to view and collaborate</div>
             </div>
-            <label className="inline-flex items-center cursor-pointer">
+            <label className="inline-flex items-center gap-2 cursor-pointer">
+              <span className={`text-xs ${isPublic ? 'text-green-400' : 'text-white/60'}`}>
+                {isPublic ? 'Public' : 'Private'}
+              </span>
               <input
                 type="checkbox"
                 className="sr-only peer"
-                checked={!!session?.isPublic}
+                checked={isPublic}
                 disabled={!isOwner}
                 onChange={async (e) => {
                   try {
@@ -73,7 +105,7 @@ export function ShareModal({ isOpen, onClose, sessionId }: ShareModalProps) {
                   }
                 }}
               />
-              <span className={`w-10 h-5 rounded-full transition-colors ${session?.isPublic ? 'bg-green-500' : 'bg-white/30'} ${!isOwner ? 'opacity-50' : ''}`}></span>
+              <span className={`w-10 h-5 rounded-full transition-colors ${isPublic ? 'bg-green-500' : 'bg-white/30'} ${!isOwner ? 'opacity-50' : ''}`}></span>
             </label>
           </div>
           {!isOwner && (

--- a/src/utils/errorMessage.ts
+++ b/src/utils/errorMessage.ts
@@ -1,0 +1,24 @@
+/**
+ * Extract a user-presentable message from an error thrown by a Convex action.
+ * Convex wraps server-side throws as
+ * "[Request ID: ...] Server Error Uncaught Error: <message> at handler ...",
+ * so strip that framing down to the original message when present.
+ */
+export function getErrorMessage(err: unknown, fallback: string): string {
+  if (!(err instanceof Error) || !err.message) return fallback
+
+  let message = err.message
+  const uncaught = message.match(/Uncaught (?:Convex)?Error: (.*)/s)
+  if (uncaught) {
+    message = uncaught[1]
+  } else {
+    // Drop Convex's "[CONVEX ...] [Request ID: ...]" framing when present
+    message = message.replace(/^(\[[^\]]*\]\s*)+/, '')
+  }
+  // Drop the stack-ish trailer Convex appends ("... at handler (../convex/foo.ts:1:1)")
+  message = message.split(/\n\s*at /)[0].trim()
+
+  // A bare "Server Error" (prod redaction) isn't actionable — use the fallback.
+  if (!message || /^server error$/i.test(message)) return fallback
+  return message
+}


### PR DESCRIPTION
## What changed

Priority 4 (A2 + S4 quick wins) from the UX audit — small diffs aimed at error/feedback trust:

- **Background removal & AI generation modals no longer swallow actionable errors.** New `src/utils/errorMessage.ts` unwraps the Convex action error framing (`[CONVEX ...] [Request ID: ...] Server Error Uncaught Error: <msg> at handler ...`) so server messages like "Insufficient tokens. Background removal costs 1 token." and "Content moderation flagged this image. Please try a different image." reach the user verbatim. A fully redacted prod error (bare "Server Error") still falls back to the generic message.
- **Share modal Copy button now gives feedback.** Transient green "Copied ✓" state for 2s (same pattern as `SessionInfo`); if clipboard access is denied, the link input is focused and its text selected so the user can copy manually.
- **Visibility toggle has a text label.** "Public"/"Private" next to the previously color-only switch.
- **Private-link warning on copy.** Copying while the session is private shows: "This session is private — recipients won't be able to open the link until you turn on Public access."

## Why

Users hitting token or moderation errors saw only "Failed to remove background / generate image. Please try again.", the Copy button gave zero feedback, and private links were shared without any hint that recipients would hit "This session is private."

## Verification

- `pnpm typecheck` passes (app + convex).
- Drove the Share modal in `pnpm dev` against an isolated local Convex deployment: Copied state, private warning appearing/disappearing with the toggle, Public/Private label, and the clipboard-denied select-text fallback (the embedded preview denies clipboard writes, exercising it for real).
- The error-unwrapping helper was tested directly in Node against realistic Convex error strings, including edge cases (redacted prod error, empty message, non-Error throw). The AI error paths couldn't be driven end-to-end in the UI because guests can't reach AI features and sign-in is Google-OAuth-only.

## Reviewer notes

- `getErrorMessage` is intentionally conservative: anything that reduces to an empty string or bare "Server Error" returns the caller's fallback.
- The AI generation modal's structured `{success, error}` path was already surfacing server errors; this only fixes the thrown-error catch path. Converting `backgroundRemoval.ts` to the structured return shape is a possible follow-up but was left out to keep the diff small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)