### PR TITLE
Per-PR preview deployments on the Mac mini

### DIFF
--- a/.claude/skills/deploy-mini/SKILL.md
+++ b/.claude/skills/deploy-mini/SKILL.md
@@ -106,6 +106,20 @@ at the tunnel: `pgrep -fl "cloudflared tunnel"`.
   Tailscale `ssh -L 6791:localhost:6791 ...`), login with the admin
   key from `selfhost/.env.convex`. Deliberately not tunnel-exposed.
 
+## PR previews (also on the mini)
+
+Open same-repo PRs are auto-served at `https://preview-pr-<N>.wepaint.ai`
+by a GitHub Actions self-hosted runner on the mini (launchd agent
+`actions.runner.wepaintai-wepaintai.mini`, `~/actions-runner`). Each
+preview is a launchd agent `com.wepaintai.preview.pr-<N>` on port
+`3300 + (N % 700)`, routed by Caddy on :3299 (`brew services`, config
+`~/apps/wepaintai-previews/Caddyfile`) behind the tunnel's
+`*.wepaint.ai` wildcard ingress rule + wildcard DNS CNAME. Previews
+share the LIVE prod Convex backend — nothing under convex/ is deployed
+for them. Full runbook: `selfhost/preview/README.md`. When debugging the
+tunnel config, the wildcard rule must stay AFTER the exact prod
+hostnames and BEFORE the http_status:404 catch-all.
+
 ## Recovery notes
 
 - Nightly backups (03:30, 14 kept): `~/Backups/wepaintai/selfhosted/`

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,25 @@
+name: Remove PR preview
+
+# Tears down the preview server, build, and Caddy route on the Mac mini when
+# a PR closes (merged or not). Deliberately checks nothing out: it only runs
+# the remover script that deploy-preview.sh installed on the mini.
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, mini]
+    steps:
+      - name: Tear down preview
+        run: |
+          SCRIPT="$HOME/apps/wepaintai-previews/bin/remove-preview.sh"
+          if [ -x "$SCRIPT" ]; then
+            "$SCRIPT" "${{ github.event.number }}"
+          else
+            echo "No remover installed on this machine; nothing to do."
+          fi

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,50 @@
+name: Deploy PR preview
+
+# Builds the PR branch on the Mac mini's self-hosted runner and serves it at
+# https://preview-pr-<N>.wepaint.ai, pointed at the LIVE production Convex
+# backend. Frontend-only: changes under convex/ are not deployed anywhere.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: preview-pr-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    # Same-repo branches only — fork PRs must never run on the mini.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, mini]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and deploy preview
+        run: ./selfhost/preview/deploy-preview.sh "${{ github.event.number }}"
+
+      - name: Comment preview URL on the PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.number }}
+        run: |
+          export PATH="/opt/homebrew/bin:$PATH"
+          MARKER="<!-- pr-preview-url -->"
+          URL="https://preview-pr-$PR.wepaint.ai/"
+          BODY=$(printf '%s\n🎨 **PR preview:** %s\n\n_Frontend preview of this branch against the **live production Convex backend** — changes under `convex/` are not deployed. Google sign-in redirects to app.wepaint.ai, so use guest mode. Redeploys on every push; torn down when the PR closes._' "$MARKER" "$URL")
+          EXISTING=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --jq "[.[] | select(.body | startswith(\"$MARKER\"))][0].id // empty")
+          if [ -n "$EXISTING" ]; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$EXISTING" -f body="$BODY" > /dev/null
+            echo "Updated existing preview comment on PR #$PR."
+          else
+            gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" -f body="$BODY" > /dev/null
+            echo "Commented preview URL on PR #$PR."
+          fi
+
+      - name: Add preview URL to summary
+        run: |
+          echo "### 🎨 Preview deployed for PR #${{ github.event.number }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "https://preview-pr-${{ github.event.number }}.wepaint.ai/" >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,9 @@ redirects to `/login`; both are a single "Continue with Google" button.
 - **Users**: app `users` rows link to Better Auth via `authId` (`identity.subject`).
   The `clerkId` field is vestigial from the pre-migration era; old rows keep it, new rows never set it.
 
+### PR Previews
+Every open same-repo PR is served at `https://preview-pr-<N>.wepaint.ai` (a sticky PR comment carries the URL). It's the prod frontend build of the branch against the **live production Convex backend** — `convex/` changes are not deployed, and sign-in is effectively guest-only. Built on the Mac mini's self-hosted runner; redeployed on every push, torn down on PR close. Details: `selfhost/preview/README.md`.
+
 ### Development Notes
 - Use `pnpm dev` for local development with free local backend
 - The admin panel (bottom-left debug info) is hidden in production

--- a/selfhost/preview/README.md
+++ b/selfhost/preview/README.md
@@ -28,7 +28,7 @@ than running a parallel stack. Consequences:
 | Cleanup workflow | [.github/workflows/cleanup-preview.yml](../../.github/workflows/cleanup-preview.yml) — `pull_request` closed |
 | Build + serve script | [deploy-preview.sh](deploy-preview.sh) (run from the PR checkout on the mini) |
 | Teardown script | [remove-preview.sh](remove-preview.sh) (deploy installs a copy at `~/apps/wepaintai-previews/bin/` so cleanup needs no checkout) |
-| Per-PR node servers | mini, `~/apps/wepaintai-previews/prs/pr-<N>/` on port `3300 + (N % 700)`, logs in `~/apps/wepaintai-previews/logs/` |
+| Per-PR node servers | mini, launchd agents `com.wepaintai.preview.pr-<N>` serving `~/apps/wepaintai-previews/prs/pr-<N>/` on port `3300 + (N % 700)`, logs in `~/apps/wepaintai-previews/logs/` |
 | Hostname router | Caddy on `:3299` (`brew services`, config `~/apps/wepaintai-previews/Caddyfile`, per-PR snippets in `caddy/*.caddy`) |
 | Public routing | Cloudflare Tunnel ingress rule `*.wepaint.ai → 127.0.0.1:3299` (in the shared `~/.cloudflared/config.yml`, after the exact prod hostnames) + wildcard DNS `*.wepaint.ai` CNAME to the tunnel |
 
@@ -46,7 +46,7 @@ than running a parallel stack. Consequences:
 
 ```bash
 # list running previews
-ssh claw@claws-mac-mini.tailc81e10.ts.net 'ls ~/apps/wepaintai-previews/prs; pgrep -fl "wepaintai-previews"'
+ssh claw@claws-mac-mini.tailc81e10.ts.net 'launchctl list | grep com.wepaintai.preview'
 
 # manually remove one
 ssh claw@claws-mac-mini.tailc81e10.ts.net '~/apps/wepaintai-previews/bin/remove-preview.sh <N>'
@@ -55,6 +55,8 @@ ssh claw@claws-mac-mini.tailc81e10.ts.net '~/apps/wepaintai-previews/bin/remove-
 ssh claw@claws-mac-mini.tailc81e10.ts.net 'tail -50 ~/apps/wepaintai-previews/logs/pr-<N>.log'
 ```
 
-Previews do not survive a mini reboot (plain `nohup` processes, no launchd);
-push to the PR again to redeploy. If a preview 404s, check Caddy
-(`launchctl list | grep caddy`) and the tunnel (`pgrep -fl cloudflared`).
+Previews run as launchd agents (a plain background process would be killed
+by the runner's orphan-process cleanup at job end), so they survive crashes
+and mini reboots. If a preview 404s, check Caddy (`launchctl list | grep
+caddy`) and the tunnel (`pgrep -fl cloudflared`); a 502 means the node
+agent is down (`tail` its log above).

--- a/selfhost/preview/README.md
+++ b/selfhost/preview/README.md
@@ -1,0 +1,60 @@
+# PR previews
+
+Every open pull request (from a branch in this repo — not forks) gets a live
+preview at **`https://preview-pr-<N>.wepaint.ai`**, redeployed on each push
+and torn down when the PR closes. A sticky comment on the PR carries the URL.
+
+## What a preview is (and isn't)
+
+A preview is the **production frontend build of the PR branch** — built with
+prod's `.env.production`, so it talks to the **live production Convex
+backend** (`api.wepaint.ai`). It extends the existing mini deployment rather
+than running a parallel stack. Consequences:
+
+- Changes under `convex/` are **not** deployed anywhere. A PR that adds or
+  changes backend functions previews against prod's currently-deployed
+  functions (new function calls will error until merged + deployed).
+- Guest painting works normally and writes real data to the prod database,
+  exactly like a guest on the prod site.
+- Google sign-in can't complete on a preview host (the OAuth redirect URI is
+  pinned to `app.wepaint.ai`), so previews are effectively guest-mode.
+
+## Moving parts
+
+| Piece | Where |
+|---|---|
+| GitHub Actions runner (label `mini`) | mini, `~/actions-runner`, launchd `actions.runner.wepaintai-wepaintai.mini` |
+| Deploy workflow | [.github/workflows/deploy-preview.yml](../../.github/workflows/deploy-preview.yml) — `pull_request` opened/reopened/synchronize |
+| Cleanup workflow | [.github/workflows/cleanup-preview.yml](../../.github/workflows/cleanup-preview.yml) — `pull_request` closed |
+| Build + serve script | [deploy-preview.sh](deploy-preview.sh) (run from the PR checkout on the mini) |
+| Teardown script | [remove-preview.sh](remove-preview.sh) (deploy installs a copy at `~/apps/wepaintai-previews/bin/` so cleanup needs no checkout) |
+| Per-PR node servers | mini, `~/apps/wepaintai-previews/prs/pr-<N>/` on port `3300 + (N % 700)`, logs in `~/apps/wepaintai-previews/logs/` |
+| Hostname router | Caddy on `:3299` (`brew services`, config `~/apps/wepaintai-previews/Caddyfile`, per-PR snippets in `caddy/*.caddy`) |
+| Public routing | Cloudflare Tunnel ingress rule `*.wepaint.ai → 127.0.0.1:3299` (in the shared `~/.cloudflared/config.yml`, after the exact prod hostnames) + wildcard DNS `*.wepaint.ai` CNAME to the tunnel |
+
+## Security notes (public repo + self-hosted runner)
+
+- Deploy/cleanup jobs are guarded with
+  `github.event.pull_request.head.repo.full_name == github.repository`, so
+  fork PRs never run on the mini.
+- The repo Actions setting "approval for fork PR workflows" is set to
+  **all outside collaborators** — fork workflow runs never start unapproved.
+- Keep it that way, and never add mini-targeting workflows triggered by
+  events fork authors control.
+
+## Ops
+
+```bash
+# list running previews
+ssh claw@claws-mac-mini.tailc81e10.ts.net 'ls ~/apps/wepaintai-previews/prs; pgrep -fl "wepaintai-previews"'
+
+# manually remove one
+ssh claw@claws-mac-mini.tailc81e10.ts.net '~/apps/wepaintai-previews/bin/remove-preview.sh <N>'
+
+# a preview's server log
+ssh claw@claws-mac-mini.tailc81e10.ts.net 'tail -50 ~/apps/wepaintai-previews/logs/pr-<N>.log'
+```
+
+Previews do not survive a mini reboot (plain `nohup` processes, no launchd);
+push to the PR again to redeploy. If a preview 404s, check Caddy
+(`launchctl list | grep caddy`) and the tunnel (`pgrep -fl cloudflared`).

--- a/selfhost/preview/deploy-preview.sh
+++ b/selfhost/preview/deploy-preview.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Build and serve a PR preview on the Mac mini.
+#
+# Run by .github/workflows/deploy-preview.yml on the mini's self-hosted
+# runner (user claw), from the PR checkout. The preview is the production
+# frontend build of the PR branch, served at
+# https://preview-pr-<N>.wepaint.ai and pointed at the LIVE production
+# Convex backend (same .env.production as prod). Nothing under convex/ is
+# deployed — backend changes in a PR are not reflected in its preview.
+#
+# Routing: Cloudflare Tunnel wildcard (*.wepaint.ai -> :3299) -> Caddy
+# (~/apps/wepaintai-previews/Caddyfile) -> per-PR node server.
+set -euo pipefail
+export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
+PR="${1:?usage: deploy-preview.sh <pr-number>}"
+case "$PR" in *[!0-9]*) echo "PR number must be numeric" >&2; exit 1 ;; esac
+
+ROOT="$HOME/apps/wepaintai-previews"
+DEST="$ROOT/prs/pr-$PR"
+PORT=$((3300 + PR % 700))
+HOST_NAME="preview-pr-$PR.wepaint.ai"
+PROD_ENV="$HOME/apps/wepaintai/.env.production"
+
+mkdir -p "$ROOT/prs" "$ROOT/caddy" "$ROOT/logs" "$ROOT/bin"
+
+# Same frontend env as production; the preview differs from prod only by
+# the branch's code. (VITE_ vars are baked into the build.)
+cp "$PROD_ENV" .env.production
+
+corepack pnpm install
+corepack pnpm build
+
+# Keep a current copy of the remover where the cleanup workflow (which
+# deliberately checks nothing out) can find it.
+cp "$(cd "$(dirname "$0")" && pwd)/remove-preview.sh" "$ROOT/bin/remove-preview.sh"
+chmod +x "$ROOT/bin/remove-preview.sh"
+
+# Replace any previous instance of this PR's preview.
+if [ -f "$DEST/pid" ]; then
+  kill "$(cat "$DEST/pid")" 2>/dev/null || true
+  sleep 1
+fi
+mkdir -p "$DEST"
+rsync -a --delete .output/ "$DEST/output/"
+
+PORT="$PORT" HOST=127.0.0.1 nohup node "$DEST/output/server/index.mjs" \
+  >> "$ROOT/logs/pr-$PR.log" 2>&1 &
+echo $! > "$DEST/pid"
+disown
+
+cat > "$ROOT/caddy/pr-$PR.caddy" <<EOF
+@pr$PR host $HOST_NAME
+handle @pr$PR {
+	reverse_proxy 127.0.0.1:$PORT
+}
+EOF
+caddy reload --config "$ROOT/Caddyfile" --adapter caddyfile
+
+ok=""
+for _ in $(seq 1 20); do
+  if curl -sf -o /dev/null "http://127.0.0.1:$PORT/"; then ok=1; break; fi
+  sleep 1
+done
+if [ -z "$ok" ]; then
+  echo "preview server failed to start; log tail:" >&2
+  tail -30 "$ROOT/logs/pr-$PR.log" >&2
+  exit 1
+fi
+echo "preview for PR #$PR serving on :$PORT -> https://$HOST_NAME/"

--- a/selfhost/preview/deploy-preview.sh
+++ b/selfhost/preview/deploy-preview.sh
@@ -37,18 +37,43 @@ corepack pnpm build
 cp "$(cd "$(dirname "$0")" && pwd)/remove-preview.sh" "$ROOT/bin/remove-preview.sh"
 chmod +x "$ROOT/bin/remove-preview.sh"
 
-# Replace any previous instance of this PR's preview.
-if [ -f "$DEST/pid" ]; then
-  kill "$(cat "$DEST/pid")" 2>/dev/null || true
-  sleep 1
-fi
+# Replace any previous instance of this PR's preview. Each preview runs as
+# a launchd agent (like prod's com.wepaintai.app): a plain background
+# process would be killed by the runner's orphan-process cleanup when the
+# job ends, and launchd also restarts previews after a mini reboot.
+LABEL="com.wepaintai.preview.pr-$PR"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+sleep 1
 mkdir -p "$DEST"
 rsync -a --delete .output/ "$DEST/output/"
 
-PORT="$PORT" HOST=127.0.0.1 nohup node "$DEST/output/server/index.mjs" \
-  >> "$ROOT/logs/pr-$PR.log" 2>&1 &
-echo $! > "$DEST/pid"
-disown
+NODE_BIN="$(command -v node)"
+cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key><string>$LABEL</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>$NODE_BIN</string>
+		<string>$DEST/output/server/index.mjs</string>
+	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PORT</key><string>$PORT</string>
+		<key>HOST</key><string>127.0.0.1</string>
+	</dict>
+	<key>WorkingDirectory</key><string>$DEST</string>
+	<key>StandardOutPath</key><string>$ROOT/logs/pr-$PR.log</string>
+	<key>StandardErrorPath</key><string>$ROOT/logs/pr-$PR.log</string>
+	<key>RunAtLoad</key><true/>
+	<key>KeepAlive</key><true/>
+</dict>
+</plist>
+EOF
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
 
 cat > "$ROOT/caddy/pr-$PR.caddy" <<EOF
 @pr$PR host $HOST_NAME

--- a/selfhost/preview/remove-preview.sh
+++ b/selfhost/preview/remove-preview.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Tear down a PR preview on the Mac mini: stop the node server, delete the
+# build and Caddy route. Run by .github/workflows/cleanup-preview.yml (via
+# the copy deploy-preview.sh installs at ~/apps/wepaintai-previews/bin/),
+# or manually: ./remove-preview.sh <pr-number>
+set -euo pipefail
+export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"
+
+PR="${1:?usage: remove-preview.sh <pr-number>}"
+case "$PR" in *[!0-9]*) echo "PR number must be numeric" >&2; exit 1 ;; esac
+
+ROOT="$HOME/apps/wepaintai-previews"
+DEST="$ROOT/prs/pr-$PR"
+
+if [ -f "$DEST/pid" ]; then
+  kill "$(cat "$DEST/pid")" 2>/dev/null || true
+fi
+rm -rf "$DEST"
+rm -f "$ROOT/caddy/pr-$PR.caddy" "$ROOT/logs/pr-$PR.log"
+caddy reload --config "$ROOT/Caddyfile" --adapter caddyfile
+echo "removed preview for PR #$PR"

--- a/selfhost/preview/remove-preview.sh
+++ b/selfhost/preview/remove-preview.sh
@@ -12,9 +12,9 @@ case "$PR" in *[!0-9]*) echo "PR number must be numeric" >&2; exit 1 ;; esac
 ROOT="$HOME/apps/wepaintai-previews"
 DEST="$ROOT/prs/pr-$PR"
 
-if [ -f "$DEST/pid" ]; then
-  kill "$(cat "$DEST/pid")" 2>/dev/null || true
-fi
+LABEL="com.wepaintai.preview.pr-$PR"
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+rm -f "$HOME/Library/LaunchAgents/$LABEL.plist"
 rm -rf "$DEST"
 rm -f "$ROOT/caddy/pr-$PR.caddy" "$ROOT/logs/pr-$PR.log"
 caddy reload --config "$ROOT/Caddyfile" --adapter caddyfile


### PR DESCRIPTION
Every open same-repo PR now gets a live preview at `https://preview-pr-<N>.wepaint.ai`, redeployed on each push and torn down when the PR closes, with a sticky comment carrying the URL.

## How it works
- **Extends the existing mini deployment** — no parallel stack. A preview is the prod frontend build of the PR branch (built with prod's `.env.production`), talking to the **live production Convex backend**.
- `deploy-preview.yml` runs on the mini's self-hosted runner (`pull_request` opened/reopened/synchronize), calls `selfhost/preview/deploy-preview.sh`: pnpm install + build, per-PR node server on port `3300 + (N % 700)`, Caddy route snippet, sticky PR comment.
- `cleanup-preview.yml` (`pull_request` closed) tears it down without checking anything out.
- Routing: Cloudflare Tunnel wildcard `*.wepaint.ai → Caddy :3299 → per-PR server` (one-time infra, already live on the mini).

## Limitations (documented in selfhost/preview/README.md)
- `convex/` changes are **not** deployed — backend-changing PRs preview against prod functions.
- Google sign-in redirects to app.wepaint.ai (OAuth redirect URI is pinned), so previews are guest-mode.
- Fork PRs never run on the mini (same-repo guard + Actions approval policy set to all outside collaborators).

This PR is its own test: the preview comment below should appear once the runner finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)