### PR TITLE
Handle invalid, deleted, and private session links gracefully

### DIFF
--- a/convex/backgroundRemoval.ts
+++ b/convex/backgroundRemoval.ts
@@ -12,13 +12,17 @@ export const removeBackground = action({
     console.log("[BG-REMOVAL] Starting background removal process");
 
     // Get the session to check ownership
-    const session = await ctx.runQuery(api.paintingSessions.getSession, {
+    const sessionResult = await ctx.runQuery(api.paintingSessions.getSession, {
       sessionId: args.sessionId,
     });
 
-    if (!session) {
+    if (sessionResult.status === "not_found") {
       throw new Error("Session not found");
     }
+    if (sessionResult.status !== "ok") {
+      throw new Error("You don't have permission to edit this painting");
+    }
+    const session = sessionResult.session;
 
     // Check authentication
     const identity = await ctx.auth.getUserIdentity();

--- a/convex/paintingSessions.ts
+++ b/convex/paintingSessions.ts
@@ -82,45 +82,56 @@ export const createSession = mutation({
   },
 });
 
+const sessionObjectValidator = v.object({
+  _id: v.id("paintingSessions"),
+  _creationTime: v.number(),
+  name: v.optional(v.string()),
+  createdBy: v.optional(v.id("users")),
+  guestOwnerKey: v.optional(v.string()),
+  isPublic: v.boolean(),
+  canvasWidth: v.number(),
+  canvasHeight: v.number(),
+  strokeCounter: v.number(),
+  paintLayerOrder: v.optional(v.number()),
+  paintLayerVisible: v.optional(v.boolean()),
+  backgroundImage: v.optional(v.string()),
+  thumbnailUrl: v.optional(v.string()),
+  lastModified: v.optional(v.number()),
+  recentStrokeOrders: v.optional(v.array(v.number())),
+  recentStrokeIds: v.optional(v.array(v.id("strokes"))),
+  deletedStrokeCount: v.optional(v.number()),
+  lastDeletedStrokeOrder: v.optional(v.number()),
+  lastAction: v.optional(v.string()),
+  lastClearBatchId: v.optional(v.string()),
+  aiPrompts: v.optional(v.array(v.string())),
+});
+
 /**
- * Get session details
+ * Get session details.
+ *
+ * Accepts an arbitrary string so that malformed session IDs (e.g. share links
+ * truncated by a chat app) resolve to `not_found` instead of throwing an
+ * ArgumentValidationError, and distinguishes a deleted/nonexistent session
+ * from one the caller isn't allowed to view.
  */
 export const getSession = query({
   args: {
-    sessionId: v.id("paintingSessions"),
+    sessionId: v.string(),
     guestKey: v.optional(v.string()),
   },
   returns: v.union(
-    v.object({
-      _id: v.id("paintingSessions"),
-      _creationTime: v.number(),
-      name: v.optional(v.string()),
-      createdBy: v.optional(v.id("users")),
-      guestOwnerKey: v.optional(v.string()),
-      isPublic: v.boolean(),
-      canvasWidth: v.number(),
-      canvasHeight: v.number(),
-      strokeCounter: v.number(),
-      paintLayerOrder: v.optional(v.number()),
-      paintLayerVisible: v.optional(v.boolean()),
-      backgroundImage: v.optional(v.string()),
-      thumbnailUrl: v.optional(v.string()),
-      lastModified: v.optional(v.number()),
-      recentStrokeOrders: v.optional(v.array(v.number())),
-      recentStrokeIds: v.optional(v.array(v.id("strokes"))),
-      deletedStrokeCount: v.optional(v.number()),
-      lastDeletedStrokeOrder: v.optional(v.number()),
-      lastAction: v.optional(v.string()),
-      lastClearBatchId: v.optional(v.string()),
-      aiPrompts: v.optional(v.array(v.string())),
-    }),
-    v.null()
+    v.object({ status: v.literal("ok"), session: sessionObjectValidator }),
+    v.object({ status: v.literal("not_found") }),
+    v.object({ status: v.literal("unauthorized") }),
   ),
   handler: async (ctx, args) => {
-    const session = await ctx.db.get(args.sessionId);
-    if (!session) return null;
+    const sessionId = ctx.db.normalizeId("paintingSessions", args.sessionId);
+    if (!sessionId) return { status: "not_found" as const };
 
-    if (session.isPublic) return session;
+    const session = await ctx.db.get(sessionId);
+    if (!session) return { status: "not_found" as const };
+
+    if (session.isPublic) return { status: "ok" as const, session };
 
     // Private: only owner can view
     const identity = await ctx.auth.getUserIdentity();
@@ -129,14 +140,14 @@ export const getSession = query({
         .query("users")
         .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
         .first();
-      if (user && session.createdBy === user._id) return session;
+      if (user && session.createdBy === user._id) return { status: "ok" as const, session };
     }
 
     // Guest ownership
     if (session.guestOwnerKey && args.guestKey && session.guestOwnerKey === args.guestKey) {
-      return session;
+      return { status: "ok" as const, session };
     }
-    return null;
+    return { status: "unauthorized" as const };
   },
 });
 

--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -240,8 +240,15 @@ export function PaintingView() {
   
   // Removed localLastStrokeInfo - now using lastStrokeInfo from usePaintingSession
 
-  const { session, createNewSession, presence, currentUser, isLoading, clearSession, undoLastStroke, redoLastStroke, strokes: rawStrokes, undoRedoAvailability, lastStrokeInfo } = usePaintingSession(sessionId)
-  
+  const { session, sessionStatus, createNewSession, presence, currentUser, isLoading, clearSession, undoLastStroke, redoLastStroke, strokes: rawStrokes, undoRedoAvailability, lastStrokeInfo } = usePaintingSession(sessionId)
+
+  // Only hit session-scoped queries once the session is confirmed accessible;
+  // a malformed URL id would otherwise throw validation errors in every query.
+  const sessionReady = !!sessionId && sessionStatus === 'ok'
+  const validSessionId = sessionReady ? sessionId : null
+  const sessionError: 'not_found' | 'unauthorized' | null =
+    sessionId && (sessionStatus === 'not_found' || sessionStatus === 'unauthorized') ? sessionStatus : null
+
   // Filter out strokes that are pending undo for optimistic UI
   // Strokes are already pre-sorted in usePaintingSession for performance
   const strokes = useMemo(() => {
@@ -255,7 +262,7 @@ export function PaintingView() {
   const updateAIImageTransform = useMutation(api.images.updateAIImageTransform)
   
   // Get images to find AI-generated ones
-  const { images, updateImageTransform, deleteImage, changeLayerOrder } = useSessionImages(sessionId)
+  const { images, updateImageTransform, deleteImage, changeLayerOrder } = useSessionImages(validSessionId)
   const aiGeneratedImages = images.filter(img => (img as any).type === 'ai-generated')
   
   // Paint layer mutations
@@ -264,15 +271,15 @@ export function PaintingView() {
   
   // Thumbnail generation
   const { generateNow: generateThumbnail } = useThumbnailGenerator({
-    sessionId: sessionId || undefined,
+    sessionId: validSessionId || undefined,
     canvasRef,
     interval: 30000, // Generate thumbnail every 30 seconds
-    enabled: !!sessionId
+    enabled: sessionReady
   })
-  const paintLayerSettings = useQuery(api.paintLayer.getPaintLayerSettings, sessionId ? { sessionId, guestKey: (typeof window !== 'undefined' ? (JSON.parse(localStorage.getItem('wepaint_guest_keys_v1') || '{}') || {})[sessionId as any] : undefined) } : 'skip')
-  
+  const paintLayerSettings = useQuery(api.paintLayer.getPaintLayerSettings, validSessionId ? { sessionId: validSessionId, guestKey: (typeof window !== 'undefined' ? (JSON.parse(localStorage.getItem('wepaint_guest_keys_v1') || '{}') || {})[validSessionId as any] : undefined) } : 'skip')
+
   // Multiple paint layers support
-  const paintLayers = useQuery(api.paintLayers.getPaintLayers, sessionId ? { sessionId, guestKey: (typeof window !== 'undefined' ? (JSON.parse(localStorage.getItem('wepaint_guest_keys_v1') || '{}') || {})[sessionId as any] : undefined) } : 'skip')
+  const paintLayers = useQuery(api.paintLayers.getPaintLayers, validSessionId ? { sessionId: validSessionId, guestKey: (typeof window !== 'undefined' ? (JSON.parse(localStorage.getItem('wepaint_guest_keys_v1') || '{}') || {})[validSessionId as any] : undefined) } : 'skip')
   const createPaintLayer = useMutation(api.paintLayers.createPaintLayer)
   const updatePaintLayer = useMutation(api.paintLayers.updatePaintLayer)
   const deletePaintLayer = useMutation(api.paintLayers.deletePaintLayer)
@@ -301,7 +308,7 @@ export function PaintingView() {
   }, [strokes, sessionId, currentUser])
   
   // Get AI generated images separately
-  const aiImages = useQuery(api.images.getAIGeneratedImages, sessionId ? { sessionId, guestKey: (typeof window !== 'undefined' ? (JSON.parse(localStorage.getItem('wepaint_guest_keys_v1') || '{}') || {})[sessionId as any] : undefined) } : 'skip')
+  const aiImages = useQuery(api.images.getAIGeneratedImages, validSessionId ? { sessionId: validSessionId, guestKey: (typeof window !== 'undefined' ? (JSON.parse(localStorage.getItem('wepaint_guest_keys_v1') || '{}') || {})[validSessionId as any] : undefined) } : 'skip')
   const updateAIImageTransformMutation = useMutation(api.images.updateAIImageTransform)
   const deleteAIImageMutation = useMutation(api.images.deleteAIImage)
   const updateAIImageLayerOrderMutation = useMutation(api.images.updateAIImageLayerOrder)
@@ -311,19 +318,16 @@ export function PaintingView() {
     // console.log('[PaintingView] AI images from direct query:', aiImages)
   }, [aiImages])
 
-  // Unauthorized overlay if session is private and user is not owner
-  const isUnauthorized = sessionId && session === null && !isLoading
-  
   // P2P connection status
-  const { 
-    isConnected: isP2PConnected, 
-    connectionMode, 
+  const {
+    isConnected: isP2PConnected,
+    connectionMode,
     metrics: p2pMetrics,
-    remoteStrokes 
+    remoteStrokes
   } = useP2PPainting({
-    sessionId,
+    sessionId: validSessionId,
     userId: currentUser.id ? currentUser.id.toString() : currentUser.name, // Convert ID to string
-    enabled: !!currentUser.id, // Only enable when user is created
+    enabled: !!currentUser.id && sessionReady, // Only enable when user is created and session is accessible
   })
 
   // Initialize P2P logger in development
@@ -414,6 +418,27 @@ export function PaintingView() {
       initSession()
     }
   }, [createNewSession, sessionId, effectiveIsSignedIn, isLoaded, authDisabled])
+
+  // Surface an error instead of spinning forever if session load/creation hangs
+  // (backend unreachable, session creation failed, etc.)
+  const [loadTimedOut, setLoadTimedOut] = useState(false)
+  useEffect(() => {
+    if (sessionReady || sessionError) {
+      setLoadTimedOut(false)
+      return
+    }
+    const timer = setTimeout(() => setLoadTimedOut(true), 20000)
+    return () => clearTimeout(timer)
+  }, [sessionReady, sessionError])
+
+  // Leave the broken session behind: drop any stored guest session and reload
+  // without the session param so a fresh painting is created.
+  const startNewPainting = useCallback(() => {
+    clearCurrentGuestSession()
+    const url = new URL(window.location.href)
+    url.searchParams.delete('session')
+    window.location.href = url.toString()
+  }, [])
 
   // Keep URL masked for guest-owned sessions; show for others and signed-in users
   useEffect(() => {
@@ -1011,10 +1036,10 @@ export function PaintingView() {
         </>
       )}
 
-      {sessionId ? (
+      {validSessionId ? (
         <KonvaCanvas
           ref={canvasRef}
-          sessionId={sessionId}
+          sessionId={validSessionId}
           color={color}
           size={size}
           opacity={opacity}
@@ -1037,10 +1062,33 @@ export function PaintingView() {
         />
       ) : (
         <div className="absolute inset-0 flex items-center justify-center bg-gray-100">
-          <div className="text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-            <p className="text-gray-600">Creating painting session...</p>
-          </div>
+          {!sessionError && (loadTimedOut ? (
+            <div className="text-center max-w-sm px-4">
+              <div className="text-gray-800 text-lg font-semibold mb-2">This is taking longer than expected</div>
+              <p className="text-gray-600 text-sm mb-4">
+                We couldn't {sessionId ? 'load' : 'create'} the painting session. Check your connection and try again.
+              </p>
+              <div className="flex items-center justify-center gap-2">
+                <button
+                  className="px-3 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white text-sm"
+                  onClick={() => window.location.reload()}
+                >
+                  Try again
+                </button>
+                <button
+                  className="px-3 py-2 bg-gray-200 hover:bg-gray-300 rounded text-gray-800 text-sm"
+                  onClick={startNewPainting}
+                >
+                  Start a new painting
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="text-center">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+              <p className="text-gray-600">{sessionId ? 'Loading painting session...' : 'Creating painting session...'}</p>
+            </div>
+          ))}
         </div>
       )}
       {adminFeaturesEnabled && (
@@ -1107,21 +1155,36 @@ export function PaintingView() {
         canUndo={((hasLocalStrokes || lastStrokeInfo !== null || (undoRedoAvailability?.canUndo ?? false))) && !isMutating}
         canRedo={(undoRedoAvailability?.canRedo ?? false) && !isMutating}
       />
-      {isUnauthorized && (
+      {sessionError && (
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/80">
           <div className="bg-black/90 border border-white/20 rounded-lg p-6 text-center max-w-sm">
-            <div className="text-white text-lg font-semibold mb-2">This session is private</div>
-            <div className="text-white/70 text-sm mb-4">Only the owner can view it unless it’s shared publicly.</div>
-            <button
-              className="px-3 py-2 bg-white/10 hover:bg-white/20 border border-white/20 rounded text-white text-sm"
-              onClick={() => {
-                const url = new URL(window.location.href)
-                url.searchParams.delete('session')
-                window.location.href = url.toString()
-              }}
-            >
-              Return to new canvas
-            </button>
+            {sessionError === 'not_found' ? (
+              <>
+                <div className="text-white text-lg font-semibold mb-2">This painting no longer exists</div>
+                <div className="text-white/70 text-sm mb-4">It may have been deleted, or the link may be incomplete or mistyped.</div>
+              </>
+            ) : (
+              <>
+                <div className="text-white text-lg font-semibold mb-2">This session is private</div>
+                <div className="text-white/70 text-sm mb-4">Only the owner can view it unless it’s shared publicly. If it’s yours, sign in to open it.</div>
+              </>
+            )}
+            <div className="flex items-center justify-center gap-2">
+              {sessionError === 'unauthorized' && (
+                <button
+                  className="px-3 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white text-sm"
+                  onClick={() => { window.location.href = '/login' }}
+                >
+                  Sign in
+                </button>
+              )}
+              <button
+                className="px-3 py-2 bg-white/10 hover:bg-white/20 border border-white/20 rounded text-white text-sm"
+                onClick={startNewPainting}
+              >
+                Start a new painting
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -13,7 +13,8 @@ interface ShareModalProps {
 
 export function ShareModal({ isOpen, onClose, sessionId }: ShareModalProps) {
   const localGuestKey = getGuestKey(sessionId)
-  const session = useQuery(api.paintingSessions.getSession, { sessionId, guestKey: localGuestKey || undefined })
+  const sessionResult = useQuery(api.paintingSessions.getSession, { sessionId, guestKey: localGuestKey || undefined })
+  const session = sessionResult?.status === 'ok' ? sessionResult.session : null
   const setVisibility = useMutation(api.paintingSessions.setSessionVisibility)
   const currentUser = useQuery(api.auth.getCurrentUser)
 

--- a/src/hooks/usePaintingSession.ts
+++ b/src/hooks/usePaintingSession.ts
@@ -90,14 +90,21 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
 
   // Queries
   const localGuestKey = guestKeyState || getGuestKey(sessionId as any);
-  const isGuest = !authenticatedUser;
-  const canAccessAsGuest = Boolean(localGuestKey);
-  // Always fetch session when we have an ID; backend will enforce access
-  const session = useQuery(
+  // Always fetch session when we have an ID; backend will enforce access.
+  // getSession accepts an arbitrary string and reports not_found for malformed
+  // IDs, so a mangled ?session= URL param never throws a validation error.
+  const sessionResult = useQuery(
     api.paintingSessions.getSession,
     sessionId ? { sessionId, guestKey: localGuestKey || undefined } : "skip"
   );
-  const canReadSessionData = Boolean(authenticatedUser) || canAccessAsGuest || (session?.isPublic === true);
+  const session = sessionResult?.status === "ok" ? sessionResult.session : null;
+  // 'loading' until both the session query and auth state have resolved, so
+  // the UI never flashes an unauthorized/not-found state for the owner.
+  const sessionStatus: 'loading' | 'ok' | 'not_found' | 'unauthorized' =
+    sessionResult === undefined || authenticatedUser === undefined
+      ? 'loading'
+      : sessionResult.status;
+  const canReadSessionData = sessionStatus === 'ok';
   
   const strokes = useQuery(
     api.strokes.getSessionStrokes,
@@ -136,8 +143,8 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
   
   // For viewer state, use user ID if authenticated, otherwise use name as viewer ID
   const viewerId = currentUser.id || currentUser.name;
-  const getViewerState = useQuery(api.viewerAcks.getViewerState, 
-    sessionId && viewerId ? { sessionId, viewerId } : "skip"
+  const getViewerState = useQuery(api.viewerAcks.getViewerState,
+    sessionId && viewerId && canReadSessionData ? { sessionId, viewerId } : "skip"
   );
 
   const localLastAckedStrokeOrderRef = useRef<number>(0);
@@ -517,6 +524,7 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
   return {
     // Data
     session,
+    sessionStatus,
     strokes: memoizedStrokes,
     lastStrokeInfo,
     presence: presence || [],
@@ -535,8 +543,6 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
     clearLiveStrokeForUser,
     
     // State
-    isLoading: sessionId !== null && (
-      session === undefined || authenticatedUser === undefined || (isGuest && !canAccessAsGuest && session?.isPublic !== true)
-    ),
+    isLoading: sessionId !== null && sessionStatus === 'loading',
   };
 }


### PR DESCRIPTION
## What

Fixes the C3 finding from the UX audit: opening `/?session=<malformed id>` (e.g. a share link truncated by a chat app) crashed the app to a raw "Something went wrong!" screen with a Convex `ArgumentValidationError` stack trace, and a valid-format ID for a deleted session showed a misleading "This session is private" overlay.

## Changes

- **Backend** (`convex/paintingSessions.ts`): `getSession` now takes `sessionId: v.string()`, resolves it with `ctx.db.normalizeId()`, and returns a discriminated union `{status: 'ok', session} | {status: 'not_found'} | {status: 'unauthorized'}` instead of `session | null`. Callers updated (`ShareModal`, `backgroundRemoval`).
- **Hook** (`src/hooks/usePaintingSession.ts`): exposes `sessionStatus` (stays `loading` until auth resolves, so owners never see a flash of "private") and gates all session-scoped queries on `status === 'ok'`. This also fixes a latent bug where guests opening someone's private link hung on the loading spinner forever.
- **UI** (`src/components/PaintingView.tsx`):
  - All queries/hooks taking the session ID (paint layers, images, AI images, P2P, thumbnails, KonvaCanvas) only receive it once the session is confirmed accessible, so a mangled URL can't reach any `v.id` validator.
  - Distinct recovery overlays: "This painting no longer exists" (not found) vs "This session is private" with a **Sign in** button (unauthorized), each with **Start a new painting**, which clears the stored guest session so guests don't loop back into a broken session.
  - The "Creating painting session…" spinner now says Loading vs Creating appropriately and times out after 20s to an error state with **Try again** / **Start a new painting**.

## Verification

- `pnpm typecheck` passes (app + convex)
- Verified live against a local Convex backend:
  - `/?session=abc123truncated` → not-found overlay, no console errors (previously: crash)
  - Valid-format nonexistent ID → not-found overlay
  - Private session owned by another guest → private overlay with Sign in
  - "Start a new painting" recovers to a fresh working canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)