### PR TITLE
Require session authorization for live stroke mutations

### DIFF
--- a/convex/liveStrokes.ts
+++ b/convex/liveStrokes.ts
@@ -1,5 +1,6 @@
 import { mutation, query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
+import { assertCanModifySession } from "./strokes";
 
 /**
  * Update or create a live stroke for a user
@@ -19,11 +20,18 @@ export const updateLiveStroke = mutation({
     brushSize: v.number(),
     opacity: v.number(),
     colorMode: v.optional(v.union(v.literal("solid"), v.literal("rainbow"))),
+    guestKey: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
+    const session = await ctx.db.get(args.sessionId);
+    if (!session) {
+      throw new Error("Session not found");
+    }
+    await assertCanModifySession(ctx, session, args.guestKey);
+
     const now = Date.now();
-    
+
     // Find existing live stroke for this user in this session
     const existingLiveStroke = await ctx.db
       .query("liveStrokes")
@@ -124,9 +132,33 @@ export const clearLiveStroke = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
     userId: v.optional(v.id("users")),
+    guestKey: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
+    const session = await ctx.db.get(args.sessionId);
+    if (!session) {
+      // Session is gone; nothing to clear
+      return null;
+    }
+    await assertCanModifySession(ctx, session, args.guestKey);
+
+    // A caller may only clear their own live stroke: a userId-scoped stroke
+    // requires the caller to be signed in as that user
+    if (args.userId) {
+      const identity = await ctx.auth.getUserIdentity();
+      if (!identity) {
+        throw new Error("Unauthorized");
+      }
+      const user = await ctx.db
+        .query("users")
+        .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
+        .first();
+      if (!user || user._id !== args.userId) {
+        throw new Error("Unauthorized");
+      }
+    }
+
     const liveStroke = await ctx.db
       .query("liveStrokes")
       .withIndex("by_user_session", (q) => 

--- a/convex/strokes.ts
+++ b/convex/strokes.ts
@@ -1,5 +1,29 @@
-import { mutation, query } from "./_generated/server";
+import { mutation, query, QueryCtx } from "./_generated/server";
 import { v } from "convex/values";
+import { Doc } from "./_generated/dataModel";
+
+/**
+ * Authorization: allow if the session is public, the caller is the signed-in
+ * owner, or the caller presents the session's guest owner key.
+ */
+export async function assertCanModifySession(
+  ctx: QueryCtx,
+  session: Doc<"paintingSessions">,
+  guestKey: string | undefined,
+): Promise<void> {
+  if (session.isPublic) return;
+  const identity = await ctx.auth.getUserIdentity();
+  if (identity) {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
+      .first();
+    if (user && session.createdBy === user._id) return;
+  }
+  if (!session.guestOwnerKey || session.guestOwnerKey !== guestKey) {
+    throw new Error("Unauthorized");
+  }
+}
 
 /**
  * Add a new stroke to a painting session
@@ -31,21 +55,7 @@ export const addStroke = mutation({
     }
 
     // Authorization: allow if public or owner or guest owner
-    if (!session.isPublic) {
-      const identity = await ctx.auth.getUserIdentity();
-      if (identity) {
-        const user = await ctx.db
-          .query("users")
-          .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
-          .first();
-        if (!user || session.createdBy !== user._id) {
-          // Fall through to guest key check
-          if (!session.guestOwnerKey || session.guestOwnerKey !== args.guestKey) throw new Error("Unauthorized");
-        }
-      } else {
-        if (!session.guestOwnerKey || session.guestOwnerKey !== args.guestKey) throw new Error("Unauthorized");
-      }
-    }
+    await assertCanModifySession(ctx, session, args.guestKey);
 
     // Increment stroke counter for ordering
     const strokeOrder = session.strokeCounter + 1;

--- a/src/hooks/usePaintingSession.ts
+++ b/src/hooks/usePaintingSession.ts
@@ -416,6 +416,7 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
         brushSize,
         opacity,
         colorMode,
+        guestKey: localGuestKey || undefined,
       });
       pendingLiveStrokeRef.current = null;
       
@@ -448,12 +449,13 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
           brushSize: pending.brushSize,
           opacity: pending.opacity,
           colorMode: pending.colorMode,
+          guestKey: localGuestKey || undefined,
         });
         pendingLiveStrokeRef.current = null;
       }
       liveStrokeUpdateRef.current = null;
     }, 16); // 16ms throttle (~60 FPS)
-  }, [sessionId, updateLiveStroke, currentUser]);
+  }, [sessionId, updateLiveStroke, currentUser, localGuestKey]);
 
   // Clear live stroke (when finishing drawing)
   const clearLiveStrokeForUser = useCallback(async () => {
@@ -464,9 +466,10 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
       return await clearLiveStroke({
         sessionId,
         userId: currentUser.id,
+        guestKey: localGuestKey || undefined,
       });
     }
-  }, [sessionId, currentUser.id, clearLiveStroke]);
+  }, [sessionId, currentUser.id, clearLiveStroke, localGuestKey]);
 
   // Leave session on unmount and cleanup timeouts
   useEffect(() => {


### PR DESCRIPTION
## What changed

- Extracted the inline authorization logic from `strokes.addStroke` into an exported `assertCanModifySession` helper in `convex/strokes.ts` (public sessions allow anyone; private sessions require the signed-in owner or a matching `guestOwnerKey`).
- Applied that helper to `liveStrokes.updateLiveStroke` and `liveStrokes.clearLiveStroke` via a new optional `guestKey` arg. `updateLiveStroke` also now validates the session exists.
- Scoped `clearLiveStroke`: when a `userId` is passed, the caller must be signed in as that user, so a caller can only clear their own live stroke. `clearLiveStroke` returns silently if the session no longer exists (nothing to clear).
- Threaded `guestKey: localGuestKey` through the three call sites in `src/hooks/usePaintingSession.ts` (immediate + throttled `updateLiveStroke`, and `clearLiveStroke`), which is the only frontend caller of these mutations.

## Why

Both mutations had no authorization: anyone with a session ID could create/overwrite live stroke previews on private sessions, and could delete another user's in-progress live stroke by passing their `userId`. Live strokes are ephemeral previews (30-second expiry), so severity is moderate, but private sessions should not accept writes from non-owners.

## Notes for reviewers

- The helper's semantics are byte-for-byte equivalent to the auth block previously inlined in `addStroke`; `addStroke` now calls the helper.
- The frontend already only calls `clearLiveStroke` for signed-in users, so the new user-match check doesn't affect any legitimate flow; stale guest strokes continue to expire via the existing `cleanupStaleLiveStrokes` cron.
- `pnpm typecheck` passes (app + convex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)