### PR TITLE
Land on a fresh canvas after sign-out and fix new-canvas loop

### DIFF
--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { X, User } from 'lucide-react'
 import { GoogleSignInButton } from './GoogleSignInButton'
 import { authClient, useAuthState } from '../lib/auth-client'
+import { clearCurrentGuestSession } from '../utils/guestKey'
 
 interface AuthModalProps {
   isOpen: boolean
@@ -14,8 +15,13 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
   const handleSignOut = async () => {
     await authClient.signOut()
     onClose()
-    // Full reload so all auth-dependent state is cleared
-    window.location.reload()
+    // Land on a fresh canvas: the current session may be private and
+    // inaccessible once signed out, so drop any reference to it and do a
+    // full navigation so all auth-dependent state is cleared
+    clearCurrentGuestSession()
+    const url = new URL(window.location.href)
+    url.searchParams.delete('session')
+    window.location.href = url.toString()
   }
 
   if (!isOpen) return null

--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -26,6 +26,7 @@ import { api } from '../../convex/_generated/api'
 import { useThumbnailGenerator } from '../hooks/useThumbnailGenerator'
 import { ClipboardProvider } from '../context/ClipboardContext'
 import { getCurrentGuestSession, setCurrentGuestSession, clearCurrentGuestSession, getGuestKey } from '../utils/guestKey'
+import { startNewCanvas } from '../utils/newCanvas'
 
 // Wrapper component for background removal modal
 function BackgroundRemovalModalWrapper({ 
@@ -377,12 +378,9 @@ export function PaintingView() {
         const existingSessionId = urlParams.get('session') as Id<"paintingSessions"> | null
         
         if (existingSessionId) {
-          // Use session from URL
+          // Use session from URL; it's recorded as the guest's current session
+          // only once access is confirmed (see effect below)
           setSessionId(existingSessionId)
-          // Record as current only for guests; URL masking handled by effect below
-          if (!effectiveIsSignedIn) {
-            setCurrentGuestSession(existingSessionId)
-          }
           return
         }
 
@@ -431,13 +429,23 @@ export function PaintingView() {
     return () => clearTimeout(timer)
   }, [sessionReady, sessionError])
 
-  // Leave the broken session behind: drop any stored guest session and reload
-  // without the session param so a fresh painting is created.
+  // Track the guest's current session in localStorage based on access:
+  // record it once confirmed accessible, and forget it when the session is
+  // private or deleted so reloads and "new canvas" don't resurrect it.
+  useEffect(() => {
+    if (!sessionId || effectiveIsSignedIn) return
+    if (sessionStatus === 'ok') {
+      setCurrentGuestSession(sessionId)
+    } else if (sessionStatus === 'not_found' || sessionStatus === 'unauthorized') {
+      if (getCurrentGuestSession() === sessionId) {
+        clearCurrentGuestSession()
+      }
+    }
+  }, [sessionId, sessionStatus, effectiveIsSignedIn])
+
+  // Leave the broken session behind so a fresh painting is created
   const startNewPainting = useCallback(() => {
-    clearCurrentGuestSession()
-    const url = new URL(window.location.href)
-    url.searchParams.delete('session')
-    window.location.href = url.toString()
+    startNewCanvas()
   }, [])
 
   // Keep URL masked for guest-owned sessions; show for others and signed-in users

--- a/src/components/ToolPanel.tsx
+++ b/src/components/ToolPanel.tsx
@@ -37,6 +37,7 @@ import { useClipboardContext } from '../context/ClipboardContext'
 import { DraggableWindow } from './DraggableWindow'
 import { ShareModal } from './ShareModal'
 import { Id } from '../../convex/_generated/dataModel'
+import { startNewCanvas } from '../utils/newCanvas'
 
 // Types
 export interface Layer {
@@ -1305,13 +1306,7 @@ export function ToolPanel({
             className="w-full px-3 py-1.5 text-left text-sm text-white hover:bg-white/20 transition-colors flex items-center gap-2"
             onClick={() => {
               setShowMenu(false)
-              // Clear the session parameter to create a new one
-              const url = new URL(window.location.href);
-              url.searchParams.delete('session');
-              window.history.pushState({}, '', url.toString());
-              try { localStorage.removeItem('wepaint_current_session_v1') } catch {}
-              // Reload to trigger new session creation
-              window.location.reload();
+              startNewCanvas()
             }}
           >
             <PlusCircle className="w-4 h-4" />
@@ -1466,14 +1461,7 @@ export function ToolPanel({
       <LibraryModal
         isOpen={isLibraryModalOpen}
         onClose={closeLibrary}
-        onCreateNew={() => {
-          // Clear the session parameter to create a new one
-          const url = new URL(window.location.href);
-          url.searchParams.delete('session');
-          window.history.pushState({}, '', url.toString());
-          // Reload to trigger new session creation
-          window.location.reload();
-        }}
+        onCreateNew={startNewCanvas}
       />
       {showShareModal && sessionId && (
         <ShareModal isOpen={showShareModal} onClose={() => setShowShareModal(false)} sessionId={sessionId} />

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -1,14 +1,17 @@
 import { useQuery } from 'convex/react'
 import { api } from '../../convex/_generated/api'
 import { authClient } from '../lib/auth-client'
+import { clearCurrentGuestSession } from '../utils/guestKey'
 
 export function UserProfile() {
   const user = useQuery(api.auth.getCurrentUser)
 
   const handleLogout = async () => {
     await authClient.signOut()
-    // Force a full page reload to ensure auth state is cleared
-    window.location.href = '/login'
+    // Land on a fresh canvas with all auth-dependent state cleared; the
+    // current session may be private and inaccessible once signed out
+    clearCurrentGuestSession()
+    window.location.href = '/'
   }
 
   if (!user) return null

--- a/src/utils/newCanvas.ts
+++ b/src/utils/newCanvas.ts
@@ -1,0 +1,10 @@
+import { clearCurrentGuestSession } from './guestKey'
+
+// Leave the current session behind: drop any stored guest session and do a
+// full navigation without the session param so a fresh painting is created.
+export function startNewCanvas() {
+  clearCurrentGuestSession()
+  const url = new URL(window.location.href)
+  url.searchParams.delete('session')
+  window.location.href = url.toString()
+}


### PR DESCRIPTION
## What

Fixes two related bugs reported on app.wepaint.ai:

1. **Signing out on a private canvas stranded you on the "This session is private" screen.** Sign-out reloaded the page with `?session=<private-id>` still in the URL, which the now-signed-out user can't access.
2. **"New canvas" looped back to the same private screen.** `PaintingView` recorded a URL-loaded session as the guest's current session in localStorage *even when access was denied*. Any load of `/` without a session param then resumed that private session, and the URL-masking effect re-added `?session=` — an inescapable loop. The Library's "Create New Canvas" also never cleared that key.

## Changes

- Sign-out (`AuthModal`, dev-only `UserProfile`) now clears the stored guest session and navigates without the session param, so the user always lands on a fresh non-private canvas.
- `PaintingView` records the guest's current session only after the backend confirms access (`sessionStatus === 'ok'`), and clears it when the session resolves to `unauthorized`/`not_found` — self-healing for users who already have a bad id stuck in localStorage.
- All new-canvas paths (menu "New Canvas", Library "Create New Canvas", private screen's "Start a new painting") now share one `startNewCanvas()` helper (clear stored session + strip `?session` + full navigation).

## Verification

Reproduced the loop locally against a local Convex backend (guest visiting a private session id): plain visits to `/` bounced back to `/?session=<private-id>` with the overlay. After the fix, the stale stored id is cleared automatically and every new-canvas path lands on a fresh blank canvas — verified in the browser. `tsc` passes; eslint shows 0 errors (pre-existing warnings only). The Google sign-out itself can't be exercised locally (no OAuth credentials), but it uses the same navigation pattern verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)