### PR TITLE
Redirect apex wepaint.ai to app.wepaint.ai to fix "Invalid origin" on sign-in

### DIFF
--- a/selfhost/preview/README.md
+++ b/selfhost/preview/README.md
@@ -16,8 +16,12 @@ than running a parallel stack. Consequences:
   functions (new function calls will error until merged + deployed).
 - Guest painting works normally and writes real data to the prod database,
   exactly like a guest on the prod site.
-- Google sign-in can't complete on a preview host (the OAuth redirect URI is
-  pinned to `app.wepaint.ai`), so previews are effectively guest-mode.
+- Google sign-in can't work on a preview host: Better Auth rejects the
+  preview origin ("Invalid origin" — only `SITE_URL` is trusted), and even a
+  trusted origin wouldn't get a session cookie back (the OAuth redirect URI
+  is pinned to `app.wepaint.ai` and cookies aren't shared across subdomains).
+  The sign-in dialog detects `preview-pr-*.wepaint.ai` and explains this
+  instead of showing the button.
 
 ## Moving parts
 

--- a/server/middleware/canonical-host.ts
+++ b/server/middleware/canonical-host.ts
@@ -1,0 +1,16 @@
+import { defineEventHandler, getRequestHost, redirect } from 'nitro/h3'
+
+/**
+ * Redirect the apex domain to the canonical app host. Auth only trusts
+ * SITE_URL (https://app.wepaint.ai): sign-in from https://wepaint.ai fails
+ * Better Auth's origin check, and the OAuth session cookie would land on the
+ * wrong host anyway. The Cloudflare tunnel routes the apex to this same node
+ * server, so canonicalize here.
+ */
+export default defineEventHandler((event) => {
+  const host = getRequestHost(event, { xForwardedHost: true })
+  if (host === 'wepaint.ai') {
+    const url = new URL(event.req.url)
+    return redirect(`https://app.wepaint.ai${url.pathname}${url.search}`, 301)
+  }
+})

--- a/src/components/GoogleSignInButton.tsx
+++ b/src/components/GoogleSignInButton.tsx
@@ -32,6 +32,13 @@ function GoogleLogo() {
 export function GoogleSignInButton({ callbackURL }: { callbackURL?: string }) {
   const [error, setError] = React.useState<string | null>(null)
   const [submitting, setSubmitting] = React.useState(false)
+  // PR previews share the prod backend but aren't a trusted auth origin, so
+  // sign-in can't work there (see selfhost/preview/README.md). Detected in an
+  // effect to keep server and client renders identical.
+  const [isPreviewHost, setIsPreviewHost] = React.useState(false)
+  React.useEffect(() => {
+    setIsPreviewHost(/^preview-pr-\d+\.wepaint\.ai$/.test(window.location.hostname))
+  }, [])
 
   const handleClick = async () => {
     setError(null)
@@ -51,6 +58,21 @@ export function GoogleSignInButton({ callbackURL }: { callbackURL?: string }) {
       setError('Sign-in failed. Please try again.')
       setSubmitting(false)
     }
+  }
+
+  if (isPreviewHost) {
+    return (
+      <p className="text-sm text-white/60 text-center">
+        Sign-in isn't available on PR previews — continue as a guest, or use{' '}
+        <a
+          href="https://app.wepaint.ai"
+          className="text-blue-400 hover:underline"
+        >
+          app.wepaint.ai
+        </a>{' '}
+        to sign in.
+      </p>
+    )
   }
 
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "vite.config.ts", "postcss.config.ts"]
+  "include": ["src", "server", "vite.config.ts", "postcss.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,8 @@ import viteReact from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
-  plugins: [tanstackStart(), nitro(), viteReact(), tailwindcss()],
+  // serverDir enables nitro's server/ conventions (middleware/, plugins/, …)
+  plugins: [tanstackStart(), nitro({ serverDir: 'server' }), viteReact(), tailwindcss()],
   ssr: {
     // Required by @convex-dev/better-auth for TanStack Start SSR
     noExternal: ['@convex-dev/better-auth'],


### PR DESCRIPTION
## What changed

- **New nitro server middleware** (`server/middleware/canonical-host.ts`): 301-redirects any request with host `wepaint.ai` to `https://app.wepaint.ai`, preserving path and query. Enabled by setting `serverDir: 'server'` in `vite.config.ts` (nitro wasn't scanning a server dir before) and added `server` to the tsconfig include.
- **Sign-in dialog on PR previews**: `GoogleSignInButton` now detects `preview-pr-*.wepaint.ai` hosts and shows "Sign-in isn't available on PR previews" with a link to app.wepaint.ai instead of letting users hit the raw error.
- **Docs**: corrected `selfhost/preview/README.md` on why preview sign-in can't work (origin check fails first, then the cookie/redirect-URI problem).

## Why

Google sign-in from `https://wepaint.ai/` failed with "Invalid origin". The Cloudflare tunnel routes the apex to the same node server as `app.wepaint.ai`, but Better Auth only trusts `SITE_URL` (`https://app.wepaint.ai`), so the origin check rejects the apex before OAuth starts. Even adding the apex to `trustedOrigins` wouldn't fix it: the OAuth callback is registered for `app.wepaint.ai`, so the session cookie would be set there and the user would land back on the apex signed out. Canonicalizing on one host solves both.

## Reviewer notes

- Verified against the production build locally: `Host: wepaint.ai` → `301 → https://app.wepaint.ai/...` with path/query intact; `app.wepaint.ai` requests pass through unchanged.
- The redirect fires before SSR/auth, so it also covers `/api/auth/*` and deep links.
- **Deploy**: frontend-only — `pnpm build` + kickstart on the mini; no `convex deploy` needed.
- The PR preview for this branch won't demonstrate the apex redirect (previews are only reachable via their own hostname), but the preview-host sign-in notice is visible there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)