### PR TITLE
Surface collaboration presence for all users

### DIFF
--- a/convex/presence.ts
+++ b/convex/presence.ts
@@ -8,6 +8,7 @@ export const updatePresence = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
     userId: v.optional(v.id("users")),
+    guestId: v.optional(v.string()),
     userColor: v.string(),
     userName: v.string(),
     cursorX: v.number(),
@@ -18,14 +19,30 @@ export const updatePresence = mutation({
   returns: v.null(),
   handler: async (ctx, args) => {
     const now = Date.now();
-    
-    // Find existing presence record
-    const existingPresence = await ctx.db
-      .query("userPresence")
-      .withIndex("by_user_session", (q) => 
-        q.eq("userId", args.userId).eq("sessionId", args.sessionId)
-      )
-      .first();
+
+    // Find existing presence record. Guests all have userId undefined, so they
+    // are keyed by their stable per-browser guestId instead.
+    const existingPresence = args.userId
+      ? await ctx.db
+          .query("userPresence")
+          .withIndex("by_user_session", (q) =>
+            q.eq("userId", args.userId).eq("sessionId", args.sessionId)
+          )
+          .first()
+      : args.guestId
+        ? await ctx.db
+            .query("userPresence")
+            .withIndex("by_guest_session", (q) =>
+              q.eq("guestId", args.guestId).eq("sessionId", args.sessionId)
+            )
+            .first()
+        : await ctx.db
+            .query("userPresence")
+            .withIndex("by_user_session", (q) =>
+              q.eq("userId", undefined).eq("sessionId", args.sessionId)
+            )
+            .filter((q) => q.eq(q.field("guestId"), undefined))
+            .first();
 
     if (existingPresence) {
       // If an identical update arrived within a short window, skip writing to reduce conflicts
@@ -44,6 +61,7 @@ export const updatePresence = mutation({
       await ctx.db.replace(existingPresence._id, {
         sessionId: args.sessionId,
         userId: args.userId,
+        guestId: args.guestId,
         userColor: args.userColor,
         userName: args.userName,
         cursorX: args.cursorX,
@@ -57,6 +75,7 @@ export const updatePresence = mutation({
       await ctx.db.insert("userPresence", {
         sessionId: args.sessionId,
         userId: args.userId,
+        guestId: args.guestId,
         userColor: args.userColor,
         userName: args.userName,
         cursorX: args.cursorX,
@@ -84,6 +103,7 @@ export const getSessionPresence = query({
     _creationTime: v.number(),
     sessionId: v.id("paintingSessions"),
     userId: v.optional(v.id("users")),
+    guestId: v.optional(v.string()),
     userColor: v.string(),
     userName: v.string(),
     cursorX: v.number(),
@@ -126,16 +146,26 @@ export const leaveSession = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
     userId: v.optional(v.id("users")),
+    guestId: v.optional(v.string()),
     userName: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    const presence = await ctx.db
-      .query("userPresence")
-      .withIndex("by_user_session", (q) => 
-        q.eq("userId", args.userId).eq("sessionId", args.sessionId)
-      )
-      .first();
+    const presence = args.userId
+      ? await ctx.db
+          .query("userPresence")
+          .withIndex("by_user_session", (q) =>
+            q.eq("userId", args.userId).eq("sessionId", args.sessionId)
+          )
+          .first()
+      : args.guestId
+        ? await ctx.db
+            .query("userPresence")
+            .withIndex("by_guest_session", (q) =>
+              q.eq("guestId", args.guestId).eq("sessionId", args.sessionId)
+            )
+            .first()
+        : null;
 
     if (presence) {
       await ctx.db.delete(presence._id);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -50,6 +50,7 @@ const schema = defineSchema({
   userPresence: defineTable({
     sessionId: v.id("paintingSessions"),
     userId: v.optional(v.id("users")),
+    guestId: v.optional(v.string()), // Stable per-browser id so guests don't collide on userId=undefined
     userColor: v.string(),
     userName: v.string(),
     cursorX: v.number(),
@@ -58,7 +59,8 @@ const schema = defineSchema({
     currentTool: v.string(),
     lastSeen: v.number(),
   }).index("by_session", ["sessionId"])
-    .index("by_user_session", ["userId", "sessionId"]),
+    .index("by_user_session", ["userId", "sessionId"])
+    .index("by_guest_session", ["guestId", "sessionId"]),
 
   liveStrokes: defineTable({
     sessionId: v.id("paintingSessions"),

--- a/src/components/KonvaCanvas.tsx
+++ b/src/components/KonvaCanvas.tsx
@@ -270,8 +270,10 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
     presence,
     liveStrokes,
     currentUser,
+    presenceGuestId,
     addStrokeToSession,
     updateUserPresence,
+    setPresenceCadence,
     updateLiveStrokeForUser,
     clearLiveStrokeForUser,
   } = usePaintingSession(sessionId)
@@ -324,6 +326,12 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
 
   // Track current stroke ID for P2P
   const [currentStrokeId, setCurrentStrokeId] = useState<string | null>(null)
+
+  // When P2P carries cursors, back Convex presence off to a coarse heartbeat;
+  // otherwise send at ~4 Hz so collaborators still see live cursors.
+  useEffect(() => {
+    setPresenceCadence(isP2PConnected ? 'coarse' : 'realtime')
+  }, [isP2PConnected, setPresenceCadence])
   
   // Track which layer is being dragged (not needed with Konva's built-in dragging)
 
@@ -586,7 +594,8 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
     strokeEndedRef.current = false
 
     setCurrentStroke([point])
-    updateUserPresence(point.x, point.y, true, selectedTool)
+    // Presence cursors render in stage coordinates, so don't send layer-local points
+    updateUserPresence(stagePoint.x, stagePoint.y, true, selectedTool)
 
     // Initialize stroke ID for P2P
     const strokeId = crypto.randomUUID()
@@ -2099,7 +2108,40 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
                 </Group>
               )
             })}
-            
+
+            {/* Fallback remote cursors from Convex presence when P2P is not connected */}
+            {!isP2PConnected && presence
+              .filter((p) => {
+                // Exclude our own presence record
+                const self = currentUser.id
+                  ? p.userId === currentUser.id
+                  : !!presenceGuestId && p.guestId === presenceGuestId
+                if (self) return false
+                // Hide cursors that have gone stale (no movement in a while)
+                return Date.now() - p.lastSeen < 15000
+              })
+              .map((p) => (
+                <Group key={p._id} x={p.cursorX} y={p.cursorY} listening={false}>
+                  <Circle
+                    radius={p.isDrawing ? 8 : 5}
+                    fill={p.userColor}
+                    stroke={p.isDrawing ? '#000000' : '#FFFFFF'}
+                    strokeWidth={p.isDrawing ? 2 : 1}
+                  />
+                  <Text
+                    text={p.userName}
+                    fontSize={11}
+                    fontStyle="bold"
+                    fill="white"
+                    stroke={p.userColor}
+                    strokeWidth={3}
+                    x={-20}
+                    y={-25}
+                    align="center"
+                  />
+                </Group>
+              ))}
+
             {/* Cursor size indicator */}
             {(() => {
               const activeLayer = layers.find(l => l.id === activeLayerId)

--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -5,6 +5,7 @@ import { ToolPanel, Layer } from './ToolPanel'
 import { type BrushSettings } from './BrushSettingsModal'
 import { AdminPanel } from './AdminPanel' // Import AdminPanel
 import { SessionInfo } from './SessionInfo'
+import { PresenceStrip } from './PresenceStrip'
 import { P2PStatus } from './P2PStatus'
 import { P2PDebugPanel } from './P2PDebugPanel'
 import { ImageUploadModal } from './ImageUploadModal'
@@ -15,6 +16,7 @@ import { ExportModal } from './ExportModal'
 import { UserProfile } from './UserProfile'
 import { TokenDisplay } from './TokenDisplay'
 import { usePaintingSession } from '../hooks/usePaintingSession'
+import { useConnectionStatus } from '../hooks/useConnectionStatus'
 import { useP2PPainting } from '../hooks/useP2PPainting'
 import { useSessionImages } from '../hooks/useSessionImages'
 import { shouldShowAdminFeatures } from '../utils/environment'
@@ -241,7 +243,8 @@ export function PaintingView() {
   
   // Removed localLastStrokeInfo - now using lastStrokeInfo from usePaintingSession
 
-  const { session, sessionStatus, createNewSession, presence, currentUser, isLoading, clearSession, undoLastStroke, redoLastStroke, strokes: rawStrokes, undoRedoAvailability, lastStrokeInfo } = usePaintingSession(sessionId)
+  const { session, sessionStatus, createNewSession, presence, currentUser, presenceGuestId, isLoading, clearSession, undoLastStroke, redoLastStroke, strokes: rawStrokes, undoRedoAvailability, lastStrokeInfo } = usePaintingSession(sessionId)
+  const connectionStatus = useConnectionStatus()
 
   // Only hit session-scoped queries once the session is confirmed accessible;
   // a malformed URL id would otherwise throw validation errors in every query.
@@ -1098,6 +1101,15 @@ export function PaintingView() {
             </div>
           ))}
         </div>
+      )}
+      {/* Presence strip + connection indicator — visible to all users */}
+      {validSessionId && (
+        <PresenceStrip
+          presence={presence}
+          currentUser={currentUser}
+          presenceGuestId={presenceGuestId}
+          connectionStatus={connectionStatus}
+        />
       )}
       {adminFeaturesEnabled && (
         <SessionInfo

--- a/src/components/PresenceStrip.tsx
+++ b/src/components/PresenceStrip.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import { Id } from '../../convex/_generated/dataModel'
+import type { UserPresence } from '../hooks/usePaintingSession'
+import type { ConnectionStatus } from '../hooks/useConnectionStatus'
+
+interface PresenceStripProps {
+  presence: UserPresence[]
+  currentUser: {
+    id: Id<'users'> | null
+    name: string
+    color: string
+  }
+  /** Stable client id identifying this browser when the user is a guest */
+  presenceGuestId?: string
+  connectionStatus: ConnectionStatus
+}
+
+// Presence records older than this are treated as gone (the server already
+// filters at 5 minutes; this keeps the strip snappier).
+const ACTIVE_WINDOW_MS = 2 * 60 * 1000
+
+function initialOf(name: string): string {
+  const trimmed = name.trim()
+  return trimmed ? trimmed[0].toUpperCase() : '?'
+}
+
+export function PresenceStrip({ presence, currentUser, presenceGuestId, connectionStatus }: PresenceStripProps) {
+  const now = Date.now()
+
+  const isSelf = (p: UserPresence) =>
+    currentUser.id ? p.userId === currentUser.id : !!presenceGuestId && p.guestId === presenceGuestId
+
+  // Dedupe collaborators by identity (userId, guestId, or record id as fallback)
+  const seen = new Set<string>()
+  const collaborators = presence.filter((p) => {
+    if (isSelf(p)) return false
+    if (now - p.lastSeen > ACTIVE_WINDOW_MS) return false
+    const key = p.userId?.toString() || p.guestId || p._id.toString()
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+
+  const onlineCount = collaborators.length + 1
+  const maxDots = 5
+  const shownCollaborators = collaborators.slice(0, maxDots)
+  const overflow = collaborators.length - shownCollaborators.length
+
+  const connectionLabel =
+    connectionStatus === 'connected' ? 'Connected' : connectionStatus === 'reconnecting' ? 'Reconnecting…' : 'Offline'
+
+  return (
+    <div
+      className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-2 bg-white/90 backdrop-blur-sm rounded-full shadow px-2.5 py-1.5 text-xs text-gray-700 select-none"
+      role="status"
+      aria-label={`${onlineCount} ${onlineCount === 1 ? 'person' : 'people'} online. ${connectionLabel}`}
+    >
+      {/* Connection indicator */}
+      {connectionStatus === 'connected' ? (
+        <span className="w-2 h-2 rounded-full bg-green-500 shrink-0" title="Connected" aria-hidden="true" />
+      ) : (
+        <span
+          className={`flex items-center gap-1 shrink-0 font-medium ${
+            connectionStatus === 'reconnecting' ? 'text-amber-600' : 'text-red-600'
+          }`}
+        >
+          <span
+            className={`w-2 h-2 rounded-full ${
+              connectionStatus === 'reconnecting' ? 'bg-amber-500 animate-pulse' : 'bg-red-500'
+            }`}
+            aria-hidden="true"
+          />
+          {connectionLabel}
+        </span>
+      )}
+
+      {/* Collaborator dots (self first) */}
+      <div className="flex items-center -space-x-1.5" aria-hidden="true">
+        <span
+          className="w-5 h-5 rounded-full ring-2 ring-white flex items-center justify-center text-[9px] font-bold text-white"
+          style={{ backgroundColor: currentUser.color }}
+          title={`${currentUser.name} (you)`}
+        >
+          {initialOf(currentUser.name)}
+        </span>
+        {shownCollaborators.map((p) => (
+          <span
+            key={p._id}
+            className="w-5 h-5 rounded-full ring-2 ring-white flex items-center justify-center text-[9px] font-bold text-white"
+            style={{ backgroundColor: p.userColor }}
+            title={p.userName}
+          >
+            {initialOf(p.userName)}
+          </span>
+        ))}
+        {overflow > 0 && (
+          <span className="w-5 h-5 rounded-full ring-2 ring-white bg-gray-400 flex items-center justify-center text-[9px] font-bold text-white">
+            +{overflow}
+          </span>
+        )}
+      </div>
+
+      <span className="text-gray-600 whitespace-nowrap">
+        {onlineCount} online
+      </span>
+    </div>
+  )
+}

--- a/src/hooks/useConnectionStatus.ts
+++ b/src/hooks/useConnectionStatus.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+import { convexHigh } from '../lib/convex'
+
+export type ConnectionStatus = 'connected' | 'reconnecting' | 'offline'
+
+/**
+ * Tracks the Convex WebSocket connection state (plus navigator.onLine) so the
+ * UI can show a live/reconnecting/offline indicator.
+ */
+export function useConnectionStatus(): ConnectionStatus {
+  // Assume connected during SSR/first paint; touching connectionState() before
+  // mount could spin up the sync client on the server.
+  const [wsConnected, setWsConnected] = useState<boolean>(true)
+  const [browserOnline, setBrowserOnline] = useState<boolean>(() =>
+    typeof navigator === 'undefined' ? true : navigator.onLine
+  )
+
+  useEffect(() => {
+    setWsConnected(convexHigh.connectionState().isWebSocketConnected)
+    const unsubscribe = convexHigh.subscribeToConnectionState((state) => {
+      setWsConnected(state.isWebSocketConnected)
+    })
+    return unsubscribe
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const handleOnline = () => setBrowserOnline(true)
+    const handleOffline = () => setBrowserOnline(false)
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [])
+
+  if (!browserOnline) return 'offline'
+  if (!wsConnected) return 'reconnecting'
+  return 'connected'
+}

--- a/src/hooks/useP2PPainting.ts
+++ b/src/hooks/useP2PPainting.ts
@@ -44,6 +44,7 @@ export function useP2PPainting({
   const [remoteCursors, setRemoteCursors] = useState<Map<string, { x: number; y: number; drawing: boolean }>>(new Map());
   const [metrics, setMetrics] = useState<P2PMetrics | null>(null);
   const metricsIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const connectedPeersRef = useRef<Set<string>>(new Set());
 
   // Handle incoming packets
   const handlePacketReceived = useCallback((peerId: string, packet: P2PPacket) => {
@@ -105,12 +106,19 @@ export function useP2PPainting({
   // Handle peer connections
   const handlePeerConnected = useCallback((peerId: string) => {
     console.log(`Peer connected: ${peerId}`);
+    connectedPeersRef.current.add(peerId);
     setIsConnected(true);
   }, []);
 
   const handlePeerDisconnected = useCallback((peerId: string) => {
     console.log(`Peer disconnected: ${peerId}`);
-    // Clean up strokes from disconnected peer
+    connectedPeersRef.current.delete(peerId);
+    // Drop back to disconnected when the last peer leaves so the app can fall
+    // back to Convex presence for cursors
+    if (connectedPeersRef.current.size === 0) {
+      setIsConnected(false);
+    }
+    // Clean up strokes and cursor from disconnected peer
     setRemoteStrokes(prev => {
       const newStrokes = new Map(prev);
       for (const [key] of newStrokes) {
@@ -119,6 +127,12 @@ export function useP2PPainting({
         }
       }
       return newStrokes;
+    });
+    setRemoteCursors(prev => {
+      if (!prev.has(peerId)) return prev;
+      const newCursors = new Map(prev);
+      newCursors.delete(peerId);
+      return newCursors;
     });
   }, []);
 
@@ -169,6 +183,7 @@ export function useP2PPainting({
       }
       manager.destroy();
       p2pManagerRef.current = null;
+      connectedPeersRef.current.clear();
       setIsConnected(false);
       setRemoteStrokes(new Map());
       setRemoteCursors(new Map());

--- a/src/hooks/usePaintingSession.ts
+++ b/src/hooks/usePaintingSession.ts
@@ -4,7 +4,7 @@ import { Id } from "../../convex/_generated/dataModel";
 import { useCallback, useEffect, useState, useRef, useMemo } from "react";
 import { p2pLogger } from "../lib/p2p-logger";
 import { convexLow } from "../lib/convex";
-import { generateGuestKey, getGuestKey, setGuestKey } from "../utils/guestKey";
+import { generateGuestKey, getGuestKey, setGuestKey, getClientId } from "../utils/guestKey";
 
 export interface PaintPoint {
   x: number;
@@ -33,6 +33,7 @@ export interface UserPresence {
   _creationTime: number;
   sessionId: Id<"paintingSessions">;
   userId?: Id<"users">;
+  guestId?: string;
   userColor: string;
   userName: string;
   cursorX: number;
@@ -259,6 +260,9 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
     return strokeId;
   }, [sessionId, addStroke, currentUser, localGuestKey]);
 
+  // Stable per-browser id used to key guest presence records (guests have no userId)
+  const presenceGuestId = currentUser.id ? undefined : getClientId();
+
   // Presence throttling and heartbeat
   const presenceIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const lastPresenceSentAtRef = useRef<number>(0);
@@ -268,7 +272,20 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
     isDrawing: boolean;
     currentTool: string;
   } | null>(null);
+  const lastSentPresenceRef = useRef<{
+    cursorX: number;
+    cursorY: number;
+    isDrawing: boolean;
+    currentTool: string;
+  } | null>(null);
   const presenceInFlightRef = useRef<boolean>(false);
+  // Cursor send cadence. Defaults to ~4 Hz so collaborators see each other's
+  // cursors via Convex presence; when P2P is connected the canvas switches to
+  // 'coarse' (20s) since cursors travel over the data channel instead.
+  const presenceThrottleMsRef = useRef<number>(250);
+  const setPresenceCadence = useCallback((mode: 'realtime' | 'coarse') => {
+    presenceThrottleMsRef.current = mode === 'realtime' ? 250 : 20000;
+  }, []);
 
   // Send the latest queued presence update if not already in flight
   const flushPresence = useCallback(async () => {
@@ -281,12 +298,17 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
       await convexLow.mutation(api.presence.updatePresence, {
         sessionId,
         userId: currentUser.id || undefined,
+        guestId: currentUser.id ? undefined : getClientId(),
         userColor: currentUser.color,
         userName: currentUser.name,
         ...payload,
       });
       lastPresenceSentAtRef.current = Date.now();
-      pendingPresenceRef.current = null;
+      lastSentPresenceRef.current = payload;
+      // Only clear if no newer update was queued while the mutation was in flight
+      if (pendingPresenceRef.current === payload) {
+        pendingPresenceRef.current = null;
+      }
     } catch (e) {
       // ignore
     } finally {
@@ -294,7 +316,8 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
     }
   }, [sessionId, currentUser.id, currentUser.color, currentUser.name]);
 
-  // Send coarse presence heartbeat every 20s using low-priority client
+  // Presence heartbeat every 20s: flush anything queued, or re-send the last
+  // position so lastSeen stays fresh and idle users still count as online.
   useEffect(() => {
     if (!sessionId) return;
 
@@ -304,7 +327,9 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
     }
 
     presenceIntervalRef.current = setInterval(() => {
-      // Heartbeat: try to flush any queued presence, but avoid overlap
+      if (!pendingPresenceRef.current && lastSentPresenceRef.current) {
+        pendingPresenceRef.current = lastSentPresenceRef.current;
+      }
       flushPresence();
     }, 20000); // 20s
 
@@ -329,7 +354,7 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
       pendingPresenceRef.current = { cursorX, cursorY, isDrawing, currentTool };
 
       const now = Date.now();
-      if (now - lastPresenceSentAtRef.current > 20000) {
+      if (now - lastPresenceSentAtRef.current > presenceThrottleMsRef.current) {
         await flushPresence();
       }
     },
@@ -473,18 +498,24 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
   useEffect(() => {
     const currentSessionId = sessionId; // Capture sessionId for cleanup
     const currentViewerId = currentUser.id; // Capture viewerId for cleanup
-    const currentUserName = currentUser.name; // Capture userName for cleanup
     return () => {
-      if (currentSessionId && currentViewerId) {
-        convexLow.mutation(api.presence.leaveSession, { sessionId: currentSessionId, userId: currentViewerId });
-        removeViewerState({ sessionId: currentSessionId, viewerId: currentViewerId });
+      if (currentSessionId) {
+        // Guests identify by their stable client id instead of a user id
+        convexLow.mutation(api.presence.leaveSession, {
+          sessionId: currentSessionId,
+          userId: currentViewerId || undefined,
+          guestId: currentViewerId ? undefined : getClientId(),
+        });
+        if (currentViewerId) {
+          removeViewerState({ sessionId: currentSessionId, viewerId: currentViewerId });
+        }
       }
       // Clean up any pending live stroke updates
       if (liveStrokeUpdateRef.current) {
         clearTimeout(liveStrokeUpdateRef.current);
       }
     };
-  }, [sessionId, leaveSession, removeViewerState, currentUser.id, currentUser.name]);
+  }, [sessionId, leaveSession, removeViewerState, currentUser.id]);
 
   // Memoized strokes with pre-sorted order and metadata for O(1) access
   const { memoizedStrokes, lastStrokeInfo } = useMemo(() => {
@@ -531,12 +562,14 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
     presence: presence || [],
     liveStrokes: liveStrokes || [],
     currentUser,
+    presenceGuestId,
     undoRedoAvailability,
-    
+
     // Actions
     createNewSession,
     addStrokeToSession,
     updateUserPresence,
+    setPresenceCadence,
     clearSession,
     undoLastStroke,
     redoLastStroke,

--- a/src/utils/guestKey.ts
+++ b/src/utils/guestKey.ts
@@ -55,3 +55,29 @@ export function clearCurrentGuestSession() {
     window.localStorage.removeItem(CURRENT_GUEST_SESSION_KEY)
   } catch {}
 }
+
+// Stable per-browser client id, used to identify guests in presence records
+// (guests have no userId, so without this they'd all collide on one record).
+export const CLIENT_ID_STORAGE = 'wepaint_client_id_v1'
+
+let inMemoryClientId: string | null = null
+
+export function getClientId(): string {
+  if (inMemoryClientId) return inMemoryClientId
+  if (typeof window === 'undefined') {
+    inMemoryClientId = generateGuestKey()
+    return inMemoryClientId
+  }
+  try {
+    let id = window.localStorage.getItem(CLIENT_ID_STORAGE)
+    if (!id) {
+      id = generateGuestKey()
+      window.localStorage.setItem(CLIENT_ID_STORAGE, id)
+    }
+    inMemoryClientId = id
+    return id
+  } catch {
+    inMemoryClientId = generateGuestKey()
+    return inMemoryClientId
+  }
+}


### PR DESCRIPTION
## What changed

Regular users couldn't see the collaboration in a collaborative app: SessionInfo/P2PStatus were admin-gated, remote cursors rendered only over P2P (guests never get P2P), there was no connection indicator, and all guests overwrote a single presence record.

- **Presence strip (default UI)**: new `PresenceStrip` pill (top-center) showing collaborator avatar dots with names/colors, online count, and a connection dot — with `role="status"` and an amber "Reconnecting…" / red "Offline" state driven by a new `useConnectionStatus` hook (`subscribeToConnectionState` + `navigator.onLine`). Debug panels stay admin-gated.
- **Cursor fallback without P2P**: when `!isP2PConnected`, `KonvaCanvas` renders collaborator cursors from Convex presence records (`cursorX/Y`, `userColor`, `userName`), hidden after 15s without updates. Presence send cadence rises from the old ~20s throttle to ~4 Hz on this path, backing off to 20s heartbeats when P2P carries cursors. The heartbeat now re-sends the last position so idle users stay counted as online.
- **Guest presence collision fix**: `userPresence` gains an optional `guestId` + `by_guest_session` index; guests are keyed by a stable per-browser client id (`getClientId()`, localStorage) instead of all colliding on `userId=undefined`, and guests now fire `leaveSession` on unmount too.
- **P2P disconnect fix**: `isP2PConnected` now resets when the last peer drops (it previously stayed `true` forever), so the cursor fallback engages after a drop; the departed peer's cursor/strokes are cleared.

## Verification

- `pnpm typecheck` passes (app + convex).
- Exercised against a live local Convex backend with a browser client: strip shows correct count, a second collaborator's presence record renders as a named cursor on canvas, two guests produce two distinct presence records, cadence measured at ~3.3 Hz while moving, offline event flips the pill and recovers, and navigating away deletes the guest's presence record.
- A `codex` second-opinion review flagged 4 issues (P2P disconnect never resetting, a dropped in-flight presence update, SSR access to `connectionState()`, layer-local coords sent on pointer-down); all fixed in this diff.

## Reviewer notes

- The second collaborator was simulated via direct `presence:updatePresence` mutations since Google OAuth can't run headlessly — a quick manual two-window pass (one signed-in, one guest) in `pnpm dev` is worth doing.
- Schema change is additive (`guestId` optional + new index); existing rows are unaffected.
- Unrelated: `pnpm dev` currently fails because `convex dev --local` is deprecated; run `vite` and `npx convex dev` separately for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)