### PR TITLE
Keep a guest's painting when they sign in

### DIFF
--- a/convex/paintingSessions.ts
+++ b/convex/paintingSessions.ts
@@ -480,6 +480,62 @@ export const claimSessionOwnership = mutation({
 });
 
 /**
+ * Claim a guest-owned session for the authenticated user.
+ *
+ * The guest key proves the caller's device created the session before they
+ * signed in, so ownership moves to their account and the key is cleared.
+ * This is how a guest's painting survives the sign-in round-trip.
+ */
+export const claimGuestSession = mutation({
+  args: {
+    sessionId: v.id("paintingSessions"),
+    guestKey: v.string(),
+  },
+  returns: v.union(
+    v.literal("claimed"),
+    v.literal("already_owned"),
+    v.literal("invalid"),
+  ),
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return "invalid";
+
+    const session = await ctx.db.get(args.sessionId);
+    if (!session) return "invalid";
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
+      .first();
+
+    if (session.createdBy !== undefined) {
+      return user && session.createdBy === user._id ? "already_owned" : "invalid";
+    }
+    if (!session.guestOwnerKey || session.guestOwnerKey !== args.guestKey) {
+      return "invalid";
+    }
+
+    // Only create a missing user row once the claim is proven valid, so bogus
+    // claim attempts can't mint accounts/welcome tokens as a side effect.
+    // Fallback: the signup trigger normally creates the row (see createSession).
+    const userId =
+      user?._id ??
+      (await createUserWithWelcomeTokens(ctx, {
+        authId: identity.subject,
+        email: identity.email,
+        name: identity.name || identity.givenName,
+      }));
+
+    await ctx.db.patch(args.sessionId, {
+      createdBy: userId,
+      guestOwnerKey: undefined,
+      lastModified: Date.now(),
+    });
+    return "claimed";
+  },
+});
+
+/**
  * Set session public accessibility (owner only)
  */
 export const setSessionVisibility = mutation({

--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -384,13 +384,24 @@ export function PaintingView() {
           return
         }
 
-        // No URL param: guests may resume their last session; signed-in (or auth-disabled) users should start fresh
-        if (!effectiveIsSignedIn) {
-          const stored = getCurrentGuestSession() as Id<"paintingSessions"> | null
-          if (stored) {
+        // No URL param: resume this device's guest session — for guests
+        // directly, and for signed-in users when they hold its guest key
+        // (they painted as a guest and just signed in; usePaintingSession
+        // claims the session for their account once it loads). Signed-in
+        // users without the key start fresh.
+        const stored = getCurrentGuestSession() as Id<"paintingSessions"> | null
+        if (stored) {
+          if (!effectiveIsSignedIn) {
             setSessionId(stored)
             return
           }
+          if (isSignedIn && getGuestKey(stored)) {
+            setSessionId(stored)
+            return
+          }
+          // Signed-in without the key: the pointer can't be claimed by this
+          // account, so drop it rather than resurrecting it on every load
+          clearCurrentGuestSession()
         }
 
         // Create new session if needed
@@ -415,7 +426,7 @@ export function PaintingView() {
     if (sessionId === null && authReady) {
       initSession()
     }
-  }, [createNewSession, sessionId, effectiveIsSignedIn, isLoaded, authDisabled])
+  }, [createNewSession, sessionId, effectiveIsSignedIn, isSignedIn, isLoaded, authDisabled])
 
   // Surface an error instead of spinning forever if session load/creation hangs
   // (backend unreachable, session creation failed, etc.)

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation } from 'convex/react'
 import { api } from '../../convex/_generated/api'
 import { Id } from '../../convex/_generated/dataModel'
 import { getGuestKey } from '../utils/guestKey'
+import { GoogleSignInButton } from './GoogleSignInButton'
 
 interface ShareModalProps {
   isOpen: boolean
@@ -111,6 +112,18 @@ export function ShareModal({ isOpen, onClose, sessionId }: ShareModalProps) {
           </div>
           {!isOwner && (
             <div className="text-xs text-yellow-300/80">Only the session owner can change sharing.</div>
+          )}
+          {currentUser === null && !!localGuestKey && (
+            <div className="border-t border-white/10 pt-4">
+              <div className="text-sm text-white/80">Keep this painting</div>
+              <div className="text-xs text-white/50 mt-1 mb-3">
+                Right now it's only saved on this device. Sign in to keep it on
+                all your devices.
+              </div>
+              <GoogleSignInButton
+                callbackURL={typeof window !== 'undefined' ? window.location.href : '/'}
+              />
+            </div>
           )}
         </div>
       </div>

--- a/src/hooks/usePaintingSession.ts
+++ b/src/hooks/usePaintingSession.ts
@@ -4,7 +4,14 @@ import { Id } from "../../convex/_generated/dataModel";
 import { useCallback, useEffect, useState, useRef, useMemo } from "react";
 import { p2pLogger } from "../lib/p2p-logger";
 import { convexLow } from "../lib/convex";
-import { generateGuestKey, getGuestKey, setGuestKey } from "../utils/guestKey";
+import {
+  generateGuestKey,
+  getGuestKey,
+  setGuestKey,
+  removeGuestKey,
+  getCurrentGuestSession,
+  clearCurrentGuestSession,
+} from "../utils/guestKey";
 
 export interface PaintPoint {
   x: number;
@@ -138,6 +145,7 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
   const upsertViewerState = useMutation(api.viewerAcks.upsertViewerState);
   const removeViewerState = useMutation(api.viewerAcks.removeViewerState);
   const claimSessionOwnership = useMutation(api.paintingSessions.claimSessionOwnership);
+  const claimGuestSession = useMutation(api.paintingSessions.claimGuestSession);
   
   // For viewer state, use user ID if authenticated, otherwise use name as viewer ID
   const viewerId = currentUser.id || currentUser.name;
@@ -175,6 +183,36 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
     if (session.hasGuestOwner) return;
     claimSessionOwnership({ sessionId });
   }, [sessionId, authenticatedUser, session, claimSessionOwnership]);
+
+  // If a signed-in user holds the guest key for a guest-owned session, they
+  // created it on this device before signing in — claim it for their account
+  // so the painting survives the sign-in round-trip.
+  const claimingGuestSessionRef = useRef(false);
+  useEffect(() => {
+    if (!sessionId || !authenticatedUser || !session) return;
+    if (!session.hasGuestOwner) return;
+    const guestKey = getGuestKey(sessionId);
+    if (!guestKey) return;
+    if (claimingGuestSessionRef.current) return;
+    claimingGuestSessionRef.current = true;
+    claimGuestSession({ sessionId, guestKey })
+      .then(() => {
+        // On success the key is spent; on "invalid" it's provably useless
+        // (wrong key or someone else owns the session) — either way, drop the
+        // local pointers so signed-in loads stop resuming this session.
+        removeGuestKey(sessionId);
+        setGuestKeyState(null);
+        if (getCurrentGuestSession() === sessionId) {
+          clearCurrentGuestSession();
+        }
+      })
+      .catch((e) => {
+        console.error("[usePaintingSession] Failed to claim guest session:", e);
+      })
+      .finally(() => {
+        claimingGuestSessionRef.current = false;
+      });
+  }, [sessionId, authenticatedUser, session, claimGuestSession]);
 
   // Remove duplicate warming queries as they're ineffective and already defined above
 

--- a/src/utils/guestKey.ts
+++ b/src/utils/guestKey.ts
@@ -30,6 +30,18 @@ export function getGuestKey(sessionId: string | null | undefined): string | null
   }
 }
 
+export function removeGuestKey(sessionId: string) {
+  if (typeof window === 'undefined') return
+  try {
+    const raw = window.localStorage.getItem(GUEST_KEYS_STORAGE)
+    const map = raw ? JSON.parse(raw) : {}
+    if (map[sessionId]) {
+      delete map[sessionId]
+      window.localStorage.setItem(GUEST_KEYS_STORAGE, JSON.stringify(map))
+    }
+  } catch {}
+}
+
 // Track current guest session ID locally so we can mask it from the URL
 export const CURRENT_GUEST_SESSION_KEY = 'wepaint_current_session_v1'
 


### PR DESCRIPTION
## What

Fixes the conversion moment destroying a guest's work (UX audit priority 5, C1 + S6). A guest who paints and then signs in with Google now returns to the same painting, owned by their account.

- **Backend**: new `claimGuestSession` mutation in `convex/paintingSessions.ts`. It verifies the presented guest key against `session.guestOwnerKey`, rewrites `createdBy` to the signed-in user, and clears the key. Returns `"claimed"` / `"already_owned"` / `"invalid"`. The key check runs *before* the missing-user-row fallback, so invalid claim attempts can't create accounts or grant welcome tokens as a side effect.
- **Sign-in return**: `initSession` in `PaintingView` now resumes the localStorage guest session for signed-in users too, when the device still holds its guest key. A new effect in `usePaintingSession` then auto-claims the session; local guest pointers (key + current-session id) are removed once the claim resolves, or when it's provably invalid. Signed-in users without a key still start fresh.
- **Share modal**: guest owners see a "Keep this painting — right now it's only saved on this device" section with the Google sign-in button, surfacing the same claim path (guest ownership is otherwise device-local localStorage only).

## Why auto-claim instead of a prompt

Clicking "Sign in" from your own canvas already expresses the intent to keep it; a "Keep your drawing?" prompt would add a failure point at exactly the moment we're trying not to lose work. Claiming is also strictly additive — the painting just becomes account-owned.

## Verification

- `pnpm typecheck` passes (app + convex).
- Backend, on a local Convex deployment via `convex run --identity`: valid claim → `"claimed"`, `createdBy` set, `hasGuestOwner: false`; retry → `"already_owned"`; wrong key / no identity / different user → `"invalid"`; the spent guest key no longer grants session access; invalid attempts create no user rows.
- Browser against local dev: paint as guest → session id + key persisted, URL masked → reload resumes the same painting → Share modal shows the new sign-in section.
- Not driveable locally: the real Google OAuth redirect (local anonymous backend has no Google credentials). Worth one manual smoke test after deploy: paint as guest on app.wepaint.ai → sign in → painting still there. Note PR previews are guest-only sign-in, so this needs prod.

## Reviewer notes

- `ctx.db.patch(..., { guestOwnerKey: undefined })` deletes the field, which is what flips `hasGuestOwner` to false for clients.
- Unrelated: `pnpm dev:convex:local` is currently broken by the Convex CLI deprecating `convex dev --local`; plain `npx convex dev` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)