### PR TITLE
security: harden token billing

### DIFF
--- a/convex/aiGeneration.ts
+++ b/convex/aiGeneration.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { mutation, action, query } from "./_generated/server";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 
 // Mutation to store AI generation requests and results
@@ -86,9 +86,8 @@ export const generateImage = action({
     }
 
     // Check if user has enough tokens (1 token per generation)
-    const tokenCost = 1;
-    const hasTokens = await ctx.runQuery(api.tokens.hasEnoughTokens, {
-      requiredTokens: tokenCost,
+    const hasTokens = await ctx.runQuery(internal.tokens.hasEnoughTokensForOperation, {
+      operationType: "ai-generation",
     });
     
     if (!hasTokens) {
@@ -360,9 +359,9 @@ export const generateImage = action({
               });
               
               // Consume tokens after successful generation
-              await ctx.runMutation(api.tokens.useTokensForGeneration, {
-                generationId,
-                tokenCost,
+              await ctx.runMutation(internal.tokens.consumeTokensForOperation, {
+                operationId: generationId,
+                operationType: "ai-generation",
               });
               
               const result = { success: true, imageUrl: finalUrl };
@@ -387,9 +386,9 @@ export const generateImage = action({
               });
               
               // Consume tokens after successful generation
-              await ctx.runMutation(api.tokens.useTokensForGeneration, {
-                generationId,
-                tokenCost,
+              await ctx.runMutation(internal.tokens.consumeTokensForOperation, {
+                operationId: generationId,
+                operationType: "ai-generation",
               });
               
               console.log('ERROR: Using fallback due to storage error');

--- a/convex/backgroundRemoval.ts
+++ b/convex/backgroundRemoval.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { action } from "./_generated/server";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 
 export const removeBackground = action({
   args: {
@@ -38,9 +38,8 @@ export const removeBackground = action({
     }
 
     // Check if user has enough tokens (1 token per background removal)
-    const tokenCost = 1;
-    const hasTokens = await ctx.runQuery(api.tokens.hasEnoughTokens, {
-      requiredTokens: tokenCost,
+    const hasTokens = await ctx.runQuery(internal.tokens.hasEnoughTokensForOperation, {
+      operationType: "background-removal",
     });
     
     if (!hasTokens) {
@@ -156,13 +155,11 @@ export const removeBackground = action({
       }
 
       // Deduct token
-      await ctx.runMutation(api.tokens.useTokens, {
-        tokenCost,
-        description: "Background removal",
-        metadata: {
-          sessionId: args.sessionId,
-          targetLayerId: args.targetLayerId,
-        },
+      await ctx.runMutation(internal.tokens.consumeTokensForOperation, {
+        operationId: crypto.randomUUID(),
+        operationType: "background-removal",
+        sessionId: args.sessionId,
+        targetLayerId: args.targetLayerId,
       });
 
       console.log("[BG-REMOVAL] Background removal successful");

--- a/convex/geminiGeneration.ts
+++ b/convex/geminiGeneration.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { action } from "./_generated/server";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 
 // Generate an image using Gemini 2.5 Flash Image (preview)
 export const generateImage = action({
@@ -21,8 +21,9 @@ export const generateImage = action({
     }
 
     // Token gating: 1 token per generation to match Replicate
-    const tokenCost = 1;
-    const hasTokens = await ctx.runQuery(api.tokens.hasEnoughTokens, { requiredTokens: tokenCost });
+    const hasTokens = await ctx.runQuery(internal.tokens.hasEnoughTokensForOperation, {
+      operationType: "ai-generation",
+    });
     if (!hasTokens) {
       console.error('[GEMINI] Insufficient tokens');
       return { success: false, error: "Insufficient tokens. Please purchase more tokens to continue." };
@@ -130,9 +131,9 @@ export const generateImage = action({
       });
 
       // Consume tokens on success
-      await ctx.runMutation(api.tokens.useTokensForGeneration, {
-        generationId,
-        tokenCost,
+      await ctx.runMutation(internal.tokens.consumeTokensForOperation, {
+        operationId: generationId,
+        operationType: "ai-generation",
       });
 
       return { success: true, imageUrl: storageUrl };
@@ -142,4 +143,3 @@ export const generateImage = action({
     }
   },
 });
-

--- a/convex/imageMerger.ts
+++ b/convex/imageMerger.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { mutation, action, query } from "./_generated/server";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 
 // Mutation to store image merge requests and results
@@ -115,9 +115,8 @@ export const mergeImages = action({
     }
 
     // Check if user has enough tokens (1 token per merge)
-    const tokenCost = 1;
-    const hasTokens = await ctx.runQuery(api.tokens.hasEnoughTokens, {
-      requiredTokens: tokenCost,
+    const hasTokens = await ctx.runQuery(internal.tokens.hasEnoughTokensForOperation, {
+      operationType: "image-merge",
     });
     
     if (!hasTokens) {
@@ -343,10 +342,9 @@ export const mergeImages = action({
               });
               
               // Consume tokens after successful merge
-              await ctx.runMutation(api.tokens.useTokensForOperation, {
+              await ctx.runMutation(internal.tokens.consumeTokensForOperation, {
                 operationId: mergeId,
                 operationType: "image-merge",
-                tokenCost,
               });
               
               const result = { success: true, imageUrl: finalUrl };
@@ -370,10 +368,9 @@ export const mergeImages = action({
               });
               
               // Consume tokens after successful merge
-              await ctx.runMutation(api.tokens.useTokensForOperation, {
+              await ctx.runMutation(internal.tokens.consumeTokensForOperation, {
                 operationId: mergeId,
                 operationType: "image-merge",
-                tokenCost,
               });
               
               console.log('[IMAGE-MERGE] Using fallback due to storage error');

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -235,6 +235,7 @@ const schema = defineSchema({
   // Token transactions
   tokenTransactions: defineTable({
     userId: v.id("users"),
+    operationKey: v.optional(v.string()),
     type: v.union(v.literal("initial"), v.literal("purchase"), v.literal("usage"), v.literal("refund")),
     amount: v.number(), // Positive for credits, negative for usage
     balance: v.number(), // Balance after transaction
@@ -249,7 +250,8 @@ const schema = defineSchema({
       targetLayerId: v.optional(v.string()),
     })),
     createdAt: v.number(),
-  }).index("by_user", ["userId", "createdAt"]),
+  }).index("by_user", ["userId", "createdAt"])
+    .index("by_user_operation", ["userId", "operationKey"]),
 
   // Polar purchase records
   polarPurchases: defineTable({

--- a/convex/test.setup.ts
+++ b/convex/test.setup.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+export const modules = import.meta.glob(['./**/*.{js,ts}', '!./**/*.test.ts', '!./test.setup.ts'])

--- a/convex/tokenPolicy.ts
+++ b/convex/tokenPolicy.ts
@@ -1,0 +1,35 @@
+export const TOKEN_COSTS = {
+  'ai-generation': 1,
+  'background-removal': 1,
+  'image-merge': 1,
+} as const
+
+export type TokenOperationType = keyof typeof TOKEN_COSTS
+
+export function getTokenCost(operationType: TokenOperationType): number {
+  return TOKEN_COSTS[operationType]
+}
+
+export function createTokenOperationKey(
+  operationType: TokenOperationType,
+  operationId: string
+): string {
+  if (!operationId.trim()) {
+    throw new Error('Operation ID is required')
+  }
+  return `${operationType}:${operationId}`
+}
+
+export function assertPositiveTokenAmount(amount: number, label = 'Token amount'): number {
+  if (!Number.isSafeInteger(amount) || amount <= 0) {
+    throw new Error(`${label} must be a positive integer`)
+  }
+  return amount
+}
+
+export function assertValidTokenBalance(balance: number): number {
+  if (!Number.isSafeInteger(balance) || balance < 0) {
+    throw new Error('Token balance must be a non-negative safe integer')
+  }
+  return balance
+}

--- a/convex/tokens.test.ts
+++ b/convex/tokens.test.ts
@@ -1,0 +1,173 @@
+import { convexTest } from 'convex-test'
+import { makeFunctionReference } from 'convex/server'
+import { describe, expect, test } from 'vitest'
+import { internal } from './_generated/api'
+import schema from './schema'
+import { modules } from './test.setup'
+
+const identity = { subject: 'auth-user-1' }
+
+function createTestBackend() {
+  return convexTest(schema, modules)
+}
+
+async function seedUser(tokens: number) {
+  const t = createTestBackend()
+  const userId = await t.run(async (ctx) => {
+    return await ctx.db.insert('users', {
+      authId: identity.subject,
+      email: 'token-test@example.com',
+      tokens,
+      lifetimeTokensUsed: 0,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+  })
+  return { t, userId, asUser: t.withIdentity(identity) }
+}
+
+describe('token billing policy', () => {
+  test('the legacy public debit endpoint no longer exists', async () => {
+    const { t, userId, asUser } = await seedUser(3)
+    const legacyDebit = makeFunctionReference<'mutation'>('tokens:useTokens')
+
+    await expect(
+      asUser.mutation(legacyDebit, {
+        tokenCost: -1_000,
+        description: 'mint tokens',
+      })
+    ).rejects.toThrow()
+
+    const user = await t.run(async (ctx) => await ctx.db.get(userId))
+    expect(user?.tokens).toBe(3)
+  })
+
+  test('rejects caller-supplied costs on the internal operation API', async () => {
+    const { t, userId, asUser } = await seedUser(3)
+
+    for (const tokenCost of [-1_000, 0, 1.5, Number.MAX_SAFE_INTEGER]) {
+      await expect(
+        asUser.mutation(internal.tokens.consumeTokensForOperation, {
+          operationId: `malicious-cost-${tokenCost}`,
+          operationType: 'background-removal',
+          tokenCost,
+        } as never)
+      ).rejects.toThrow()
+    }
+
+    const user = await t.run(async (ctx) => await ctx.db.get(userId))
+    expect(user?.tokens).toBe(3)
+  })
+
+  test('charges the fixed server price exactly once for duplicate requests', async () => {
+    const { t, userId, asUser } = await seedUser(3)
+    const args = {
+      operationId: 'background-removal-1',
+      operationType: 'background-removal' as const,
+    }
+
+    const [first, duplicate] = await Promise.all([
+      asUser.mutation(internal.tokens.consumeTokensForOperation, args),
+      asUser.mutation(internal.tokens.consumeTokensForOperation, args),
+    ])
+
+    expect([first.charged, duplicate.charged].sort()).toEqual([false, true])
+
+    const state = await t.run(async (ctx) => ({
+      user: await ctx.db.get(userId),
+      transactions: await ctx.db
+        .query('tokenTransactions')
+        .withIndex('by_user_operation', (q) => q.eq('userId', userId))
+        .collect(),
+    }))
+
+    expect(state.user?.tokens).toBe(2)
+    expect(state.user?.lifetimeTokensUsed).toBe(1)
+    expect(state.transactions).toHaveLength(1)
+    expect(state.transactions[0]).toMatchObject({
+      operationKey: 'background-removal:background-removal-1',
+      amount: -1,
+      balance: 2,
+      type: 'usage',
+    })
+  })
+
+  test('requires authentication and enforces insufficient balance', async () => {
+    const unauthenticated = createTestBackend()
+    await expect(
+      unauthenticated.mutation(internal.tokens.consumeTokensForOperation, {
+        operationId: 'anonymous-operation',
+        operationType: 'ai-generation',
+      })
+    ).rejects.toThrow('Not authenticated')
+
+    const { asUser } = await seedUser(0)
+    await expect(
+      asUser.mutation(internal.tokens.consumeTokensForOperation, {
+        operationId: 'no-balance',
+        operationType: 'background-removal',
+      })
+    ).rejects.toThrow('Insufficient tokens')
+  })
+
+  test('rejects invalid purchase credits and balance overflow', async () => {
+    const { t, userId } = await seedUser(3)
+
+    for (const tokens of [-1, 0, 1.5, Number.NaN]) {
+      await expect(
+        t.mutation(internal.tokens.creditTokensFromPurchase, {
+          userId,
+          tokens,
+          polarCheckoutId: `invalid-${String(tokens)}`,
+          polarProductId: 'test-product',
+          description: 'Invalid purchase',
+        })
+      ).rejects.toThrow('Purchase tokens must be a positive integer')
+    }
+
+    await expect(
+      t.mutation(internal.tokens.creditTokensFromPurchase, {
+        userId,
+        tokens: Number.MAX_SAFE_INTEGER,
+        polarCheckoutId: 'overflow',
+        polarProductId: 'test-product',
+        description: 'Overflow purchase',
+      })
+    ).rejects.toThrow('Token balance must be a non-negative safe integer')
+
+    const user = await t.run(async (ctx) => await ctx.db.get(userId))
+    expect(user?.tokens).toBe(3)
+  })
+
+  test('credits a purchase checkout at most once', async () => {
+    const { t, userId } = await seedUser(3)
+    const purchase = {
+      userId,
+      tokens: 5,
+      polarCheckoutId: 'checkout-once',
+      polarProductId: 'test-product',
+      description: 'Five token purchase',
+    }
+
+    await Promise.all([
+      t.mutation(internal.tokens.creditTokensFromPurchase, purchase),
+      t.mutation(internal.tokens.creditTokensFromPurchase, purchase),
+    ])
+
+    const state = await t.run(async (ctx) => ({
+      user: await ctx.db.get(userId),
+      transactions: await ctx.db
+        .query('tokenTransactions')
+        .withIndex('by_user', (q) => q.eq('userId', userId))
+        .collect(),
+    }))
+
+    expect(state.user?.tokens).toBe(8)
+    expect(state.transactions).toHaveLength(1)
+    expect(state.transactions[0]).toMatchObject({
+      type: 'purchase',
+      amount: 5,
+      balance: 8,
+    })
+  })
+})

--- a/convex/tokens.ts
+++ b/convex/tokens.ts
@@ -1,6 +1,19 @@
-import { query, mutation, internalMutation } from "./_generated/server";
+import { query, internalMutation, internalQuery } from "./_generated/server";
 import { v } from "convex/values";
 import { Id } from "./_generated/dataModel";
+import {
+  assertPositiveTokenAmount,
+  assertValidTokenBalance,
+  createTokenOperationKey,
+  getTokenCost,
+  type TokenOperationType,
+} from "./tokenPolicy";
+
+const tokenOperationValidator = v.union(
+  v.literal("ai-generation"),
+  v.literal("background-removal"),
+  v.literal("image-merge"),
+);
 
 // Get user's current token balance
 export const getTokenBalance = query({
@@ -92,11 +105,14 @@ export const getTokenHistory = query({
   },
 });
 
-// Use tokens for AI generation
-export const useTokensForGeneration = mutation({
+// Token consumption is internal-only. Callers identify the completed operation;
+// this mutation owns the price, authentication, and idempotency policy.
+export const consumeTokensForOperation = internalMutation({
   args: {
-    generationId: v.id("aiGenerations"),
-    tokenCost: v.number(),
+    operationId: v.string(),
+    operationType: tokenOperationValidator,
+    sessionId: v.optional(v.id("paintingSessions")),
+    targetLayerId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
@@ -113,98 +129,94 @@ export const useTokensForGeneration = mutation({
       throw new Error("User not found");
     }
 
-    const currentTokens = user.tokens ?? 0;
-    if (currentTokens < args.tokenCost) {
-      throw new Error("Insufficient tokens");
-    }
-
-    // Update user tokens
-    const newBalance = currentTokens - args.tokenCost;
-    await ctx.db.patch(user._id, {
-      tokens: newBalance,
-      lifetimeTokensUsed: (user.lifetimeTokensUsed ?? 0) + args.tokenCost,
-      updatedAt: Date.now(),
-    });
-
-    // Record transaction
-    await ctx.db.insert("tokenTransactions", {
-      userId: user._id,
-      type: "usage",
-      amount: -args.tokenCost,
-      balance: newBalance,
-      description: "AI image generation",
-      metadata: {
-        aiGenerationId: args.generationId,
-      },
-      createdAt: Date.now(),
-    });
-
-    return { newBalance };
-  },
-});
-
-// Generic token consumption for different operation types
-export const useTokensForOperation = mutation({
-  args: {
-    operationId: v.string(), // Generic ID for any operation
-    operationType: v.union(v.literal("ai-generation"), v.literal("background-removal"), v.literal("image-merge")),
-    tokenCost: v.number(),
-  },
-  handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) {
-      throw new Error("Not authenticated");
-    }
-
-    const user = await ctx.db
-      .query("users")
-      .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
+    const operationType: TokenOperationType = args.operationType;
+    const operationKey = createTokenOperationKey(operationType, args.operationId);
+    const existingTransaction = await ctx.db
+      .query("tokenTransactions")
+      .withIndex("by_user_operation", (q) =>
+        q.eq("userId", user._id).eq("operationKey", operationKey),
+      )
       .first();
 
-    if (!user) {
-      throw new Error("User not found");
+    if (existingTransaction) {
+      return { newBalance: existingTransaction.balance, charged: false };
     }
 
-    const currentTokens = user.tokens ?? 0;
-    if (currentTokens < args.tokenCost) {
+    const tokenCost = assertPositiveTokenAmount(getTokenCost(operationType));
+    const currentTokens = assertValidTokenBalance(user.tokens ?? 0);
+    if (currentTokens < tokenCost) {
       throw new Error("Insufficient tokens");
     }
 
-    // Update user tokens
-    const newBalance = currentTokens - args.tokenCost;
+    const newBalance = currentTokens - tokenCost;
     await ctx.db.patch(user._id, {
       tokens: newBalance,
-      lifetimeTokensUsed: (user.lifetimeTokensUsed ?? 0) + args.tokenCost,
+      lifetimeTokensUsed: (user.lifetimeTokensUsed ?? 0) + tokenCost,
       updatedAt: Date.now(),
     });
 
-    // Record transaction with appropriate description and metadata
     const descriptions = {
       "ai-generation": "AI image generation",
       "background-removal": "Background removal",
-      "image-merge": "Image merge operation"
-    };
+      "image-merge": "Image merge operation",
+    } as const;
 
-    const metadata: any = {};
-    if (args.operationType === "ai-generation") {
-      metadata.aiGenerationId = args.operationId;
-    } else if (args.operationType === "background-removal") {
+    const metadata: {
+      aiGenerationId?: Id<"aiGenerations">;
+      backgroundRemovalId?: string;
+      imageMergeId?: Id<"imageMerges">;
+      sessionId?: string;
+      targetLayerId?: string;
+    } = {};
+
+    if (operationType === "ai-generation") {
+      const generationId = ctx.db.normalizeId("aiGenerations", args.operationId);
+      if (!generationId) throw new Error("Invalid AI generation ID");
+      metadata.aiGenerationId = generationId;
+    } else if (operationType === "background-removal") {
       metadata.backgroundRemovalId = args.operationId;
-    } else if (args.operationType === "image-merge") {
-      metadata.imageMergeId = args.operationId;
+      metadata.sessionId = args.sessionId;
+      metadata.targetLayerId = args.targetLayerId;
+    } else {
+      const imageMergeId = ctx.db.normalizeId("imageMerges", args.operationId);
+      if (!imageMergeId) throw new Error("Invalid image merge ID");
+      metadata.imageMergeId = imageMergeId;
     }
 
     await ctx.db.insert("tokenTransactions", {
       userId: user._id,
+      operationKey,
       type: "usage",
-      amount: -args.tokenCost,
+      amount: -tokenCost,
       balance: newBalance,
-      description: descriptions[args.operationType],
+      description: descriptions[operationType],
       metadata,
       createdAt: Date.now(),
     });
 
-    return { newBalance };
+    return { newBalance, charged: true };
+  },
+});
+
+// Balance checks are also internal and use the same server-owned price table.
+export const hasEnoughTokensForOperation = internalQuery({
+  args: {
+    operationType: tokenOperationValidator,
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return false;
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
+      .first();
+
+    if (!user) return false;
+    const requiredTokens = assertPositiveTokenAmount(
+      getTokenCost(args.operationType),
+    );
+    return (user.tokens ?? 0) >= requiredTokens;
   },
 });
 
@@ -218,6 +230,8 @@ export const creditTokensFromPurchase = internalMutation({
     description: v.string(),
   },
   handler: async (ctx, args) => {
+    const tokens = assertPositiveTokenAmount(args.tokens, "Purchase tokens");
+
     // Check if transaction already exists for this checkout (duplicate prevention)
     const existingTransaction = await ctx.db
       .query("tokenTransactions")
@@ -240,8 +254,8 @@ export const creditTokensFromPurchase = internalMutation({
       throw new Error("User not found");
     }
 
-    const currentTokens = user.tokens ?? 0;
-    const newBalance = currentTokens + args.tokens;
+    const currentTokens = assertValidTokenBalance(user.tokens ?? 0);
+    const newBalance = assertValidTokenBalance(currentTokens + tokens);
 
     // Update user tokens
     await ctx.db.patch(args.userId, {
@@ -253,7 +267,7 @@ export const creditTokensFromPurchase = internalMutation({
     await ctx.db.insert("tokenTransactions", {
       userId: args.userId,
       type: "purchase",
-      amount: args.tokens,
+      amount: tokens,
       balance: newBalance,
       description: args.description,
       metadata: {
@@ -264,99 +278,5 @@ export const creditTokensFromPurchase = internalMutation({
     });
 
     return { newBalance };
-  },
-});
-
-// Generic token usage mutation
-export const useTokens = mutation({
-  args: {
-    tokenCost: v.number(),
-    description: v.string(),
-    metadata: v.optional(v.any()),
-  },
-  handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) {
-      throw new Error("Not authenticated");
-    }
-
-    const user = await ctx.db
-      .query("users")
-      .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
-      .first();
-
-    if (!user) {
-      throw new Error("User not found");
-    }
-
-    const currentTokens = user.tokens ?? 0;
-    if (currentTokens < args.tokenCost) {
-      throw new Error("Insufficient tokens");
-    }
-
-    // Update user tokens
-    const newBalance = currentTokens - args.tokenCost;
-    await ctx.db.patch(user._id, {
-      tokens: newBalance,
-      lifetimeTokensUsed: (user.lifetimeTokensUsed ?? 0) + args.tokenCost,
-      updatedAt: Date.now(),
-    });
-
-    // Record transaction
-    await ctx.db.insert("tokenTransactions", {
-      userId: user._id,
-      type: "usage",
-      amount: -args.tokenCost,
-      balance: newBalance,
-      description: args.description,
-      metadata: args.metadata || {},
-      createdAt: Date.now(),
-    });
-
-    return { newBalance };
-  },
-});
-
-// Check if user has enough tokens
-export const hasEnoughTokens = query({
-  args: {
-    requiredTokens: v.number(),
-  },
-  handler: async (ctx, args) => {
-    // Return false immediately if running in an environment without auth
-    if (typeof ctx.auth === 'undefined') {
-      console.log("[hasEnoughTokens] Running without auth context");
-      return false;
-    }
-    
-    try {
-      // Check if auth is available
-      if (!ctx.auth || typeof ctx.auth.getUserIdentity !== 'function') {
-        console.log("[hasEnoughTokens] Auth not properly configured");
-        return false;
-      }
-      
-      let identity;
-      try {
-        identity = await ctx.auth.getUserIdentity();
-      } catch (authError) {
-        console.log("[hasEnoughTokens] Auth error:", authError);
-        return false;
-      }
-      
-      if (!identity) return false;
-
-      const user = await ctx.db
-        .query("users")
-        .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
-        .first();
-
-      if (!user) return false;
-
-      return (user.tokens ?? 0) >= args.requiredTokens;
-    } catch (error) {
-      console.error("[hasEnoughTokens] Error:", error);
-      return false;
-    }
   },
 });

--- a/docs/SECURITY_PERFORMANCE_AUDIT.md
+++ b/docs/SECURITY_PERFORMANCE_AUDIT.md
@@ -1,0 +1,604 @@
+# Security, Performance, and Quality Improvement Backlog
+
+Last reviewed: 2026-07-09
+
+This document tracks the repository audit findings so work can continue across separate Codex sessions. Update the status, notes, and verification fields as each item progresses.
+
+## Status and priority conventions
+
+- Status: `TODO`, `IN PROGRESS`, `BLOCKED`, `DONE`, or `ACCEPTED RISK`.
+- P0: exploitable security or billing issue; address before production exposure.
+- P1: high-impact security, data integrity, reliability, or scalability issue.
+- P2: important performance, maintainability, privacy, accessibility, or operational improvement.
+- P3: documentation and general cleanup.
+
+## Recommended execution order
+
+1. Fix P0 token and payment exploits.
+2. Centralize authorization and secure every public Convex function.
+3. Make AI billing atomic and harden provider workflows.
+4. Secure uploads and add storage lifecycle cleanup.
+5. Remove duplicate subscriptions and make stroke loading scalable.
+6. Add regression tests and CI gates.
+7. Address deployment, privacy, accessibility, and maintainability debt.
+
+---
+
+## P0 — Critical
+
+### AUD-001: Prevent arbitrary token minting
+
+- Status: DONE
+- Area: Billing / Convex security
+- Files:
+  - `convex/tokens.ts` (`consumeTokensForOperation`)
+  - `convex/tokenPolicy.ts`
+  - `convex/tokens.test.ts`
+  - `convex/schema.ts`
+- Problem: Public mutations accept a caller-supplied `tokenCost`. A negative value turns subtraction into an arbitrary balance credit.
+- Required changes:
+  - Make debit mutations internal-only.
+  - Determine operation costs on the server; never accept cost or description from the client.
+  - Validate all monetary/token values as finite positive integers.
+  - Add an idempotency key per billed operation.
+- Acceptance criteria:
+  - Negative, zero, fractional, `NaN`, and excessive costs are rejected.
+  - Clients cannot call a generic balance-changing mutation.
+  - Duplicate operation IDs cannot be charged or credited twice.
+  - Tests cover concurrent and malicious requests.
+- Verification: `corepack pnpm test:run` PASS (6 tests); `corepack pnpm typecheck` PASS; `corepack pnpm build` PASS with the pre-existing large-chunk warning; targeted ESLint PASS with 0 errors and 9 pre-existing warnings in legacy AI provider files.
+- Notes: Completed 2026-07-09. Removed all three public debit mutations and the public caller-supplied balance check. Added a fixed server price policy, an internal authenticated debit mutation, per-user operation idempotency keys/index, safe-integer balance validation, and guarded purchase credits. Updated Replicate, Gemini, background-removal, and image-merge callers. Added Vitest and `convex-test` coverage for the removed public endpoint, malicious cost fields, duplicate concurrent debits, authentication, insufficient balance, invalid/overflow credits, and duplicate purchase delivery. The optional `operationKey` schema field/index must be deployed with the Convex changes. Atomic pre-provider reservation remains tracked separately in AUD-006.
+
+### AUD-002: Derive Polar package value server-side
+
+- Status: TODO
+- Area: Payments
+- Files:
+  - `convex/polar.ts`
+  - `convex/polarWebhook.ts`
+  - `convex/schema.ts`
+- Problem: Checkout accepts arbitrary `productId` and `tokens`, then credits the caller-supplied token quantity after payment.
+- Required changes:
+  - Accept a server-defined package key such as `small` or `large`.
+  - Map package key to product ID, price, currency, and token amount on the server.
+  - Validate webhook product, amount, currency, customer/user binding, and checkout status.
+  - Store the validated server package rather than client metadata.
+- Acceptance criteria:
+  - A client cannot alter the product/token mapping.
+  - A valid payment for one product can only grant that product's configured tokens.
+  - Webhook replay and duplicate delivery are idempotent.
+  - Tests cover mismatched product, amount, currency, and token metadata.
+- Verification: Not run
+- Notes:
+
+### AUD-003: Fail closed and sanitize Polar webhook handling
+
+- Status: TODO
+- Area: Payments / Secrets
+- Files:
+  - `convex/polarWebhook.ts`
+- Problem: Missing `POLAR_WEBHOOK_SECRET` falls back to an empty HMAC key. Logs also expose headers, computed signatures, event bodies, and a secret prefix.
+- Required changes:
+  - Reject requests or deployment initialization when the webhook secret is missing.
+  - Use the provider-supported verification library or one canonical secret format.
+  - Remove secret, signature, header, and full event logging.
+  - Credit tokens and mark the purchase complete in one idempotent internal mutation.
+- Acceptance criteria:
+  - An unset secret cannot produce a valid webhook.
+  - No sensitive signature or secret material appears in logs.
+  - A transient credit failure does not permanently mark a purchase completed.
+  - Timestamp and replay protections are tested.
+- Verification: Not run
+- Notes:
+
+### AUD-004: Enforce authorization on every Convex function
+
+- Status: TODO
+- Area: Authorization / Data integrity
+- Primary files:
+  - `convex/images.ts`
+  - `convex/paintLayers.ts`
+  - `convex/paintLayer.ts`
+  - `convex/layers.ts`
+  - `convex/paintingSessions.ts`
+  - `convex/aiGeneration.ts`
+  - `convex/imageMerger.ts`
+  - `convex/presence.ts`
+  - `convex/viewerAcks.ts`
+  - `convex/webrtc.ts`
+- Problem: Many public queries and mutations can read, create, modify, reorder, or delete records without checking session access. Client-supplied `userId` values also allow impersonation.
+- Required changes:
+  - Add a shared authorization module for session read, collaborate, owner, and admin policies.
+  - Apply it to every public query, mutation, and action.
+  - Derive authenticated user IDs from `ctx.auth`; do not trust client `userId` fields.
+  - Verify every child resource belongs to the authorized session.
+  - Require guest edit capabilities where anonymous collaboration is allowed.
+  - Add rate limits and bounded input validation to public write endpoints.
+- Acceptance criteria:
+  - Cross-session reads and writes fail.
+  - Private-session resources cannot be accessed using only a record ID.
+  - A caller cannot attribute activity to another user.
+  - Every public Convex export has an explicit documented access policy and test.
+- Verification: Not run
+- Notes:
+
+---
+
+## P1 — High priority
+
+### AUD-005: Separate public discovery, viewing, and editing
+
+- Status: TODO
+- Area: Sharing model
+- Files:
+  - `convex/strokes.ts` (`assertCanModifySession`)
+  - `convex/paintingSessions.ts`
+  - `src/components/ShareModal.tsx`
+- Problem: `isPublic` grants write access, and public sessions are enumerable. Anyone can potentially vandalize a public painting.
+- Required changes:
+  - Replace the single flag with explicit visibility and collaboration policy.
+  - Use editor memberships, signed invite tokens, or a separate secret edit link.
+  - Keep public gallery/read access read-only by default.
+- Acceptance criteria:
+  - Public viewers cannot mutate without an edit capability.
+  - Owners can revoke edit access.
+  - Existing sessions receive a safe migration default.
+- Verification: Not run
+- Notes:
+
+### AUD-006: Reserve AI tokens atomically before provider spending
+
+- Status: TODO
+- Area: AI billing / Concurrency
+- Files:
+  - `convex/aiGeneration.ts`
+  - `convex/geminiGeneration.ts`
+  - `convex/backgroundRemoval.ts`
+  - `convex/imageMerger.ts`
+  - `convex/tokens.ts`
+- Problem: Actions check balance, incur provider cost, and deduct afterward. Concurrent requests can all pass the initial balance check.
+- Required changes:
+  - Atomically reserve/debit tokens before starting external work.
+  - Associate the reservation with an immutable operation ID.
+  - Refund exactly once when an operation fails before producing a usable result.
+  - Enforce per-user concurrency and rate limits.
+- Acceptance criteria:
+  - A one-token balance cannot launch multiple paid operations concurrently.
+  - Retries do not create duplicate provider work or charges.
+  - Success, failure, timeout, and cancellation paths reconcile correctly.
+- Verification: Not run
+- Notes:
+
+### AUD-007: Fix background-removal ownership comparison
+
+- Status: TODO
+- Area: Correctness / Authorization
+- Files:
+  - `convex/backgroundRemoval.ts`
+- Problem: `session.createdBy` is a Convex user ID while `identity.subject` is an authentication subject string, so legitimate owners can be rejected.
+- Required changes:
+  - Use the centralized authorization helper from AUD-004.
+  - Remove the incompatible direct ID comparison.
+- Acceptance criteria:
+  - Session owners can use the operation.
+  - Non-editors cannot use it against the session.
+  - Tests cover owner, guest editor, public viewer, and unrelated user.
+- Verification: Not run
+- Notes:
+
+### AUD-008: Replace the client-side password gate
+
+- Status: TODO
+- Area: Authentication
+- Files:
+  - `src/components/PasswordProtection.tsx`
+  - `src/routes/__root.tsx`
+- Problem: The password is hardcoded in client JavaScript and authentication state is a client-controlled `sessionStorage` value. It provides no security boundary.
+- Required changes:
+  - Remove the component if it is only a visual preview gate, or replace it with server-side authentication/middleware.
+  - Rotate the exposed password if it is reused anywhere else.
+- Acceptance criteria:
+  - Protected routes and APIs reject unauthenticated requests server-side.
+  - No access password is shipped in the browser bundle.
+- Verification: Not run
+- Notes:
+
+### AUD-009: Secure image uploads and storage registration
+
+- Status: TODO
+- Area: Upload security / Cost control
+- Files:
+  - `convex/images.ts`
+  - `src/utils/imageUpload.ts`
+- Problem: Anyone can request an upload URL, and server mutations trust client MIME type, dimensions, filename, storage ID, session, and user ID. The 5 MB/type checks exist only in the browser.
+- Required changes:
+  - Authorize upload URL generation for a specific session.
+  - Add server-side file size, decoded type, image dimension, and ownership validation.
+  - Bind issued upload intents to user/session and consume them once.
+  - Reject unregistered storage IDs and remove abandoned uploads.
+- Acceptance criteria:
+  - Bypassing the frontend cannot upload arbitrary type/size content.
+  - A storage object cannot be attached to an unauthorized session.
+  - Abandoned objects expire or are cleaned up.
+- Verification: Not run
+- Notes:
+
+### AUD-010: Implement storage lifecycle and cascading deletion
+
+- Status: TODO
+- Area: Data lifecycle / Cost
+- Files:
+  - `convex/paintingSessions.ts`
+  - `convex/images.ts`
+  - `convex/aiGeneration.ts`
+  - `convex/geminiGeneration.ts`
+  - `convex/backgroundRemoval.ts`
+  - `convex/imageMerger.ts`
+  - `convex/schema.ts`
+- Problem: Session deletion removes only the parent record. AI input/output files often lack stored storage IDs and cannot be deleted, leaving orphaned documents and blobs.
+- Required changes:
+  - Record storage IDs for every persisted input and output.
+  - Add bounded cascading deletion jobs for session-owned tables and storage.
+  - Add cleanup for failed, timed-out, abandoned, and superseded operations.
+  - Consider soft deletion plus an asynchronous purge workflow.
+- Acceptance criteria:
+  - Deleting a session eventually removes all owned documents and blobs.
+  - Failed AI operations do not leak input/output storage.
+  - Cleanup is resumable and safe to retry.
+- Verification: Not run
+- Notes:
+
+### AUD-011: Bound and validate all untrusted inputs
+
+- Status: TODO
+- Area: Abuse prevention
+- Files: All public functions under `convex/`
+- Problem: Names, prompts, point arrays, dimensions, transforms, viewer IDs, peer IDs, WebRTC payloads, history arrays, and numeric values are largely unbounded.
+- Required changes:
+  - Define shared maximums and validation helpers.
+  - Reject non-finite coordinates/scales and out-of-range opacity/brush values.
+  - Limit prompt/name/filename lengths, stroke point counts, signal sizes, and history lengths.
+  - Add per-user/IP/session rate limits where supported.
+- Acceptance criteria:
+  - Oversized payloads fail before database/provider work.
+  - Stored numeric values are finite and within documented bounds.
+  - Abuse tests cover storage, mutation frequency, and large payloads.
+- Verification: Not run
+- Notes:
+
+### AUD-012: Protect WebRTC peer identity and signaling
+
+- Status: TODO
+- Area: Collaboration security
+- Files:
+  - `convex/webrtc.ts`
+  - `src/lib/webrtc/P2PManager.ts`
+- Problem: Peer IDs are client-controlled and not bound to a caller. A session participant can potentially read or delete another peer's signals or impersonate a sender.
+- Required changes:
+  - Issue or register peer identities per authorized connection.
+  - Bind signaling reads/deletes/sends to that identity.
+  - Limit signal payload size and message rate.
+- Acceptance criteria:
+  - One peer cannot retrieve or delete another peer's signaling queue.
+  - Sender identity cannot be forged.
+- Verification: Not run
+- Notes:
+
+---
+
+## P2 — Performance, reliability, and operations
+
+### AUD-013: Eliminate duplicate editor subscriptions and side effects
+
+- Status: TODO
+- Area: Frontend performance / Correctness
+- Files:
+  - `src/components/PaintingView.tsx`
+  - `src/components/KonvaCanvas.tsx`
+  - `src/hooks/usePaintingSession.ts`
+  - `src/hooks/useSessionImages.ts`
+  - `src/hooks/useP2PPainting.ts`
+- Problem: The page and canvas independently instantiate painting, image, AI-image, paint-layer, and P2P hooks, creating duplicate reactive queries, presence timers, random guest identities, and P2P lifecycles.
+- Required changes:
+  - Instantiate editor/session state once in a provider or controller hook.
+  - Pass normalized state and stable actions into the canvas and panels.
+  - Remove duplicate AI-image queries already covered by the combined image query.
+- Acceptance criteria:
+  - One active subscription per logical dataset per editor.
+  - One presence heartbeat and one P2P manager per session tab.
+  - Query/write counts are measured before and after.
+- Verification: Not run
+- Notes:
+
+### AUD-014: Make stroke storage and subscriptions scalable
+
+- Status: TODO
+- Area: Convex performance / Canvas rendering
+- Files:
+  - `convex/strokes.ts`
+  - `src/hooks/usePaintingSession.ts`
+  - `src/components/KonvaCanvas.tsx`
+- Problem: `getSessionStrokes` collects and returns every stroke with every point on each reactive update. Large paintings will increase bandwidth, render cost, and risk Convex read limits.
+- Required changes:
+  - Use paginated initial loading plus incremental recent operations.
+  - Avoid retransmitting immutable historical strokes after every change.
+  - Snapshot/flatten older strokes into tiles, vector chunks, or raster checkpoints.
+  - Virtualize or cache per-layer drawing where practical.
+- Acceptance criteria:
+  - Adding one stroke does not resend the full painting history.
+  - A documented large-canvas benchmark remains responsive and within read limits.
+  - Undo/redo behavior remains correct across snapshots.
+- Verification: Not run
+- Notes:
+
+### AUD-015: Fix thumbnail generation and storage
+
+- Status: TODO
+- Area: CPU / Database bandwidth
+- Files:
+  - `src/hooks/useThumbnailGenerator.ts`
+  - `convex/paintingSessions.ts`
+  - `convex/schema.ts`
+- Problem: Every interval scans full-resolution pixels on the main thread. The change check compares a source image data URL with the previous JPEG thumbnail, so it does not detect unchanged canvases. Thumbnails are stored inline in session documents.
+- Required changes:
+  - Trigger generation from a canvas revision/change counter.
+  - Generate directly at thumbnail resolution without a full-size pixel scan.
+  - Store the thumbnail in file storage and retain a storage ID/URL.
+  - Authorize thumbnail updates.
+- Acceptance criteria:
+  - An unchanged canvas produces no thumbnail encode or database write.
+  - Thumbnail work does not create a noticeable main-thread stall.
+  - Session list queries do not read embedded base64 image payloads.
+- Verification: Not run
+- Notes:
+
+### AUD-016: Add client code splitting
+
+- Status: TODO
+- Area: Bundle performance
+- Files:
+  - `src/routes/index.tsx`
+  - `src/components/PaintingView.tsx`
+  - Modal and admin/debug components under `src/components/`
+- Baseline: Production build produced initial chunks of approximately 468.35 KB and 643.42 KB minified (134.32 KB and 205.30 KB gzip).
+- Required changes:
+  - Lazy-load AI, export, library, admin/debug, background removal, and merge workflows.
+  - Evaluate route-level lazy loading for the editor and Konva dependencies.
+  - Add a bundle-size budget to CI.
+- Acceptance criteria:
+  - No initial client chunk exceeds the agreed budget.
+  - Editor startup behavior is verified on a throttled mobile profile.
+- Verification: Baseline recorded 2026-07-09
+- Notes:
+
+### AUD-017: Replace long provider polling actions
+
+- Status: TODO
+- Area: AI reliability / Scalability
+- Files:
+  - `convex/aiGeneration.ts`
+  - `convex/backgroundRemoval.ts`
+  - `convex/imageMerger.ts`
+- Problem: Actions poll external providers once per second for up to roughly 180 seconds, consuming action capacity and complicating retries.
+- Required changes:
+  - Prefer provider webhooks where available.
+  - Otherwise schedule bounded status checks with persisted state and backoff.
+  - Add cancellation and stale-operation cleanup.
+- Acceptance criteria:
+  - No action remains active solely to sleep and poll for minutes.
+  - Provider retries and duplicate callbacks are idempotent.
+- Verification: Not run
+- Notes:
+
+### AUD-018: Reduce sensitive and high-volume logging
+
+- Status: TODO
+- Area: Privacy / Operations
+- Files:
+  - AI functions under `convex/`
+  - `convex/polarWebhook.ts`
+  - `convex/paintingSessions.ts`
+  - `src/components/KonvaCanvas.tsx`
+  - `src/components/PaintingView.tsx`
+  - `src/lib/webrtc/`
+- Problem: Production paths log prompts, image samples/URLs, identities, headers, provider responses, peer information, and frequent interaction details.
+- Required changes:
+  - Add a structured logger with environment-aware levels.
+  - Redact prompts, URLs, headers, identities, tokens, and provider payloads.
+  - Remove per-stroke, per-poll, and render-path logs from production.
+- Acceptance criteria:
+  - Production logs contain no secrets or user content.
+  - Log volume remains bounded during drawing and provider polling.
+- Verification: Not run
+- Notes:
+
+### AUD-019: Harden self-hosting configuration
+
+- Status: TODO
+- Area: Deployment security
+- Files:
+  - `selfhost/docker-compose.yml`
+  - `selfhost/launchd/`
+  - `server/middleware/`
+- Problem: Containers use unpinned `latest` tags, backend/dashboard ports bind to every interface, and repository code defines no browser security headers.
+- Required changes:
+  - Pin container versions or immutable digests.
+  - Bind internal ports to `127.0.0.1` unless LAN exposure is explicitly required.
+  - Add CSP, HSTS, frame-ancestors, Referrer-Policy, and Permissions-Policy at the effective edge/server layer.
+  - Document Cloudflare and host firewall assumptions.
+- Acceptance criteria:
+  - Internal services are not unintentionally reachable from LAN/WAN.
+  - Deployment versions are reproducible.
+  - Security headers are verified against production responses.
+- Verification: Not run
+- Notes:
+
+### AUD-020: Add automated tests and CI gates
+
+- Status: TODO
+- Area: Quality engineering
+- Files:
+  - `package.json`
+  - New test files and `.github/workflows/`
+- Problem: There is no configured test runner or CI workflow.
+- Required changes:
+  - Add Vitest for server/unit tests and React Testing Library for UI behavior.
+  - Add Playwright for critical editor, sharing, upload, and billing flows.
+  - Run pinned-pnpm install, typecheck, lint, test, build, and audit in CI.
+  - Make P0/P1 security regression tests required checks.
+- Acceptance criteria:
+  - Pull requests cannot merge with failing typecheck, tests, or build.
+  - Critical authorization, token, payment, and concurrency paths have regression coverage.
+- Verification: Not run
+- Notes:
+
+### AUD-021: Pay down lint and React correctness warnings
+
+- Status: TODO
+- Area: Maintainability
+- Files:
+  - `eslint.config.js`
+  - Warnings across `src/` and `convex/`
+- Baseline:
+  - Project-only scan: 198 warnings.
+  - Top groups: 85 explicit `any`, 50 unused variables, 16 hook dependency issues, and 15 state-in-effect warnings.
+  - Default `eslint .` also scans nested `.claude` worktrees and reported 1,191 warnings.
+- Required changes:
+  - Ignore nested worktrees and agent/runtime directories.
+  - Resolve React hook dependency, purity, refs, and state-in-effect warnings first.
+  - Gradually promote correctness rules from warnings to errors.
+- Acceptance criteria:
+  - Lint scans only the intended repository source.
+  - No React correctness warnings remain.
+  - CI enforces an agreed warning budget trending toward zero.
+- Verification: Baseline recorded 2026-07-09
+- Notes:
+
+### AUD-022: Split oversized editor modules
+
+- Status: TODO
+- Area: Architecture
+- Files:
+  - `src/components/KonvaCanvas.tsx` (approximately 2,218 lines)
+  - `src/components/ToolPanel.tsx` (approximately 1,479 lines)
+  - `src/components/PaintingView.tsx` (approximately 1,287 lines)
+- Required changes:
+  - Separate canvas rendering, pointer input, layer transforms, upload handling, keyboard shortcuts, P2P previews, tool panels, and modal orchestration.
+  - Establish narrow typed interfaces between controller and view components.
+- Acceptance criteria:
+  - High-frequency canvas updates do not rerender unrelated panels/modals.
+  - Core modules have focused tests and clearly bounded responsibilities.
+- Verification: Not run
+- Notes:
+
+### AUD-023: Add privacy controls for analytics
+
+- Status: TODO
+- Area: Privacy
+- Files:
+  - `src/client.tsx`
+- Problem: PostHog initializes unconditionally, while the repository contains no privacy/consent surface or documented data policy.
+- Required changes:
+  - Make analytics environment-controlled.
+  - Determine and document the legal consent model for deployed regions.
+  - Disable capture of prompts, canvas content, session IDs, and sensitive DOM text.
+  - Honor opt-out and applicable browser privacy signals.
+- Acceptance criteria:
+  - Development/self-hosted installations can disable analytics completely.
+  - Sensitive editor and authentication data is excluded from analytics.
+- Verification: Not run
+- Notes:
+
+### AUD-024: Improve accessibility coverage
+
+- Status: TODO
+- Area: Accessibility
+- Files:
+  - `src/routes/__root.tsx`
+  - Modal components under `src/components/`
+  - Canvas/tool controls
+- Problem: No accessibility linting or automated testing is configured. The root lacks `lang`, several modals lack dialog/focus-management semantics, and some icon controls lack accessible labels.
+- Required changes:
+  - Add `eslint-plugin-jsx-a11y` and automated axe checks.
+  - Add `lang`, dialog semantics, focus trap/restore, Escape handling, and labeled controls.
+  - Define a keyboard-accessible alternative for essential canvas actions.
+- Acceptance criteria:
+  - Primary flows pass automated axe checks.
+  - All interactive controls are keyboard reachable and named.
+  - Modals correctly manage focus.
+- Verification: Not run
+- Notes:
+
+---
+
+## P3 — Documentation and developer experience
+
+### AUD-025: Correct setup and architecture documentation
+
+- Status: TODO
+- Area: Documentation
+- Files:
+  - `README.md`
+  - `.env.example`
+  - `docs/`
+- Problem: README port and directory examples are stale, production prerequisites are incomplete, and security assumptions are not documented.
+- Required changes:
+  - Align ports and commands with `package.json`.
+  - Replace `/app` examples with the current `src/` structure.
+  - Document required app and Convex environment variables separately.
+  - Document the public/read/edit model and production deployment checklist.
+- Acceptance criteria:
+  - A clean clone can be started from the README without undocumented steps.
+  - Production startup fails with clear messages for every missing required variable.
+- Verification: Not run
+- Notes:
+
+### AUD-026: Enforce the repository-pinned pnpm version
+
+- Status: TODO
+- Area: Developer experience / Reproducibility
+- Files:
+  - `package.json`
+  - Future CI workflows
+- Problem: Bare pnpm 11 ignored the current `pnpm` configuration and produced an incompatible local dependency state; `corepack pnpm` correctly selected pnpm 10.34.4.
+- Required changes:
+  - Use Corepack in README, deployment scripts, and CI.
+  - Add an engine/package-manager guard if contributors frequently use global pnpm.
+- Acceptance criteria:
+  - Local and CI installs use the pinned package-manager version.
+  - Frozen-lockfile installation is reproducible.
+- Verification: `corepack pnpm install --frozen-lockfile` passed 2026-07-09
+- Notes:
+
+---
+
+## Audit verification baseline
+
+Recorded on 2026-07-09 after installing with the repository-pinned pnpm version:
+
+- `corepack pnpm typecheck`: PASS
+- `corepack pnpm build`: PASS with large client chunk warning
+- `corepack pnpm audit --prod`: PASS, no known advisories reported
+- Project-only ESLint scan: 0 errors, 198 warnings
+- Default `corepack pnpm lint`: 0 errors, 1,191 warnings because nested `.claude` worktrees are included
+- Automated tests: NOT AVAILABLE
+- Browser smoke test: NOT COMPLETED; required Convex URLs were not configured in the audit environment
+- Secret-pattern scan: no committed provider private keys found; the client-side access password remains tracked under AUD-008
+
+## Template for future session handoff
+
+Copy this into a new task and replace the ID:
+
+> Work on `AUD-XXX` from `docs/SECURITY_PERFORMANCE_AUDIT.md`. Inspect the current implementation, update the backlog item to `IN PROGRESS`, implement the complete fix with tests, run the relevant verification commands, then mark it `DONE` only if every acceptance criterion passes. Record key decisions and command results in the item's Notes and Verification fields. Do not modify unrelated user changes.
+
+## Completion checklist for each item
+
+- [ ] Status updated before and after work
+- [ ] Threat model or failure mode understood
+- [ ] Implementation completed
+- [ ] Unit/integration tests added
+- [ ] Typecheck passed
+- [ ] Relevant lint passed
+- [ ] Production build passed when frontend/build behavior changed
+- [ ] Security or performance acceptance criteria verified
+- [ ] Notes record migrations, deployment steps, or follow-up risks

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "typecheck": "run-s typecheck:app typecheck:convex",
     "typecheck:app": "tsc --noEmit",
     "typecheck:convex": "tsc -p convex --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
@@ -87,10 +89,12 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@edge-runtime/vm": "^5.0.0",
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "convex-test": "^0.0.54",
     "eslint": "^10.6.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.1",
@@ -98,6 +102,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.9.4",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.63.0"
+    "typescript-eslint": "^8.63.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
     dependencies:
       '@convex-dev/better-auth':
         specifier: ^0.12.5
-        version: 0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.23(@tanstack/react-start@1.168.27(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(convex@1.42.1(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
+        version: 0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.23(@tanstack/react-start@1.168.27(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@edge-runtime/vm@5.0.0)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5))))(convex@1.42.1(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
       '@polar-sh/sdk':
         specifier: ^0.48.1
         version: 0.48.1
@@ -64,7 +64,7 @@ importers:
         version: 10.5.2(postcss@8.5.16)
       better-auth:
         specifier: ~1.6.23
-        version: 1.6.23(@tanstack/react-start@1.168.27(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.6.23(@tanstack/react-start@1.168.27(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@edge-runtime/vm@5.0.0)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -117,6 +117,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@edge-runtime/vm':
+        specifier: ^5.0.0
+        version: 5.0.0
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
@@ -129,6 +132,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      convex-test:
+        specifier: ^0.0.54
+        version: 0.0.54(convex@1.42.1(react@19.2.7))
       eslint:
         specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)
@@ -153,6 +159,9 @@ importers:
       typescript-eslint:
         specifier: ^8.63.0
         version: 8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@edge-runtime/vm@5.0.0)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5))
 
 packages:
 
@@ -316,6 +325,14 @@ packages:
       better-auth: '>=1.6.11 <1.7.0'
       convex: ^1.25.0
       react: ^18.3.1 || ^19.0.0
+
+  '@edge-runtime/primitives@6.0.0':
+    resolution: {integrity: sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA==}
+    engines: {node: '>=18'}
+
+  '@edge-runtime/vm@5.0.0':
+    resolution: {integrity: sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==}
+    engines: {node: '>=18'}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -1401,6 +1418,12 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -1506,6 +1529,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.4.3
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1537,6 +1589,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1668,6 +1724,10 @@ packages:
   caniuse-lite@1.0.30001803:
     resolution: {integrity: sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -1728,6 +1788,11 @@ packages:
         optional: true
       zod:
         optional: true
+
+  convex-test@0.0.54:
+    resolution: {integrity: sha512-C0v2SQcuxrELAJRNzE6fQ686XDPor7UFoC22jcoJXeCRqhLo8ZIMZ4jyUHoo1UdAL2enCb0AbiprCVpLDN8u9Q==}
+    peerDependencies:
+      convex: ^1.32.0
 
   convex@1.42.1:
     resolution: {integrity: sha512-yFKp4xerVuBwQqpuTtvosOk9F/fX0twZs+Xti3oj/MlwPUU90QuhgCYo/I2wvFBAFwXsmx9tXpf2q8ekh1+3ug==}
@@ -1894,6 +1959,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1983,9 +2051,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.1.0:
     resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
@@ -2554,6 +2629,10 @@ packages:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   ocache@0.1.5:
     resolution: {integrity: sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==}
 
@@ -2820,6 +2899,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2852,11 +2934,17 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2909,9 +2997,20 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -3151,6 +3250,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.4.3
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-vitals@5.3.0:
     resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
@@ -3180,6 +3320,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3379,10 +3524,10 @@ snapshots:
 
   '@better-fetch/fetch@1.3.1': {}
 
-  '@convex-dev/better-auth@0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.23(@tanstack/react-start@1.168.27(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(convex@1.42.1(react@19.2.7))(react@19.2.7)(typescript@5.9.3)':
+  '@convex-dev/better-auth@0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.23(@tanstack/react-start@1.168.27(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@edge-runtime/vm@5.0.0)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5))))(convex@1.42.1(react@19.2.7))(react@19.2.7)(typescript@5.9.3)':
     dependencies:
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.23(@tanstack/react-start@1.168.27(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      better-auth: 1.6.23(@tanstack/react-start@1.168.27(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@edge-runtime/vm@5.0.0)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)))
       common-tags: 1.8.2
       convex: 1.42.1(react@19.2.7)
       convex-helpers: 0.1.120(@standard-schema/spec@1.1.0)(convex@1.42.1(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(zod@4.4.3)
@@ -3396,6 +3541,12 @@ snapshots:
       - '@standard-schema/spec'
       - hono
       - typescript
+
+  '@edge-runtime/primitives@6.0.0': {}
+
+  '@edge-runtime/vm@5.0.0':
+    dependencies:
+      '@edge-runtime/primitives': 6.0.0
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -4200,6 +4351,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
@@ -4325,6 +4483,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -4361,6 +4560,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   async-function@1.0.0: {}
 
   autoprefixer@10.5.2(postcss@8.5.16):
@@ -4391,7 +4592,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
-  better-auth@1.6.23(@tanstack/react-start@1.168.27(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  better-auth@1.6.23(@tanstack/react-start@1.168.27(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@edge-runtime/vm@5.0.0)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5))):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
@@ -4414,6 +4615,7 @@ snapshots:
       '@tanstack/react-start': 1.168.27(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5))
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+      vitest: 4.1.10(@edge-runtime/vm@5.0.0)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -4466,6 +4668,8 @@ snapshots:
 
   caniuse-lite@1.0.30001803: {}
 
+  chai@6.2.2: {}
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -4506,6 +4710,10 @@ snapshots:
       react: 19.2.7
       typescript: 5.9.3
       zod: 4.4.3
+
+  convex-test@0.0.54(convex@1.42.1(react@19.2.7)):
+    dependencies:
+      convex: 1.42.1(react@19.2.7)
 
   convex@1.42.1(react@19.2.7):
     dependencies:
@@ -4680,6 +4888,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -4872,7 +5082,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   exsolve@1.1.0: {}
 
@@ -5411,6 +5627,8 @@ snapshots:
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
+  obug@2.1.3: {}
+
   ocache@0.1.5:
     dependencies:
       ohash: 2.0.11
@@ -5729,6 +5947,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -5758,6 +5978,8 @@ snapshots:
 
   srvx@0.11.21: {}
 
+  stackback@0.0.2: {}
+
   standard-as-callback@2.1.0:
     optional: true
 
@@ -5765,6 +5987,8 @@ snapshots:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -5825,10 +6049,16 @@ snapshots:
       source-map-support: 0.5.21
     optional: true
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -5970,6 +6200,34 @@ snapshots:
     optionalDependencies:
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)
 
+  vitest@4.1.10(@edge-runtime/vm@5.0.0)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.40.0)(tsx@4.20.5)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 5.0.0
+      '@types/node': 26.1.0
+    transitivePeerDependencies:
+      - msw
+
   web-vitals@5.3.0: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -6022,6 +6280,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['convex/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

- add a prioritized security, performance, and quality audit backlog
- remove public token-debit mutations and client-controlled token costs
- centralize fixed operation prices in a server-only policy
- add authenticated, idempotent internal debits with safe-integer balance validation
- update Replicate, Gemini, background-removal, and image-merge callers
- add Vitest and convex-test regression coverage

## Root cause

Token debit mutations trusted a caller-supplied numeric cost. A negative cost inverted the subtraction and allowed an authenticated client to mint an arbitrary token balance. Checkout credit values remain tracked separately as AUD-002.

## Impact

Clients can no longer call a balance-changing debit API or choose an operation cost. Duplicate operation and purchase delivery attempts are charged or credited at most once.

This adds the optional `tokenTransactions.operationKey` field and `by_user_operation` index, so the Convex schema/functions must be deployed with the application changes.

Atomic token reservation before provider work remains tracked as AUD-006.

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm test:run` — 6 tests passed
- `corepack pnpm build`
- `corepack pnpm audit --prod` — no known vulnerabilities
- targeted ESLint and Prettier checks
