### PR TITLE
payments: fail closed on Polar webhooks

### DIFF
--- a/convex/polar.test.ts
+++ b/convex/polar.test.ts
@@ -52,10 +52,153 @@ function completedCheckout(
   }
 }
 
+const webhookSecret = 'polar-webhook-secret'
+
+function checkoutUpdatedEvent(
+  userId: Id<'users'>,
+  overrides: Partial<{
+    checkoutId: string
+    status: string
+    productId: string | null
+    amount: number
+    currency: string
+    externalCustomerId: string | null
+  }> = {}
+) {
+  const now = new Date().toISOString()
+  const checkout = {
+    checkoutId: 'checkout-50',
+    status: 'succeeded',
+    productId: 'polar-product-50' as string | null,
+    amount: 499,
+    currency: 'usd',
+    externalCustomerId: String(userId) as string | null,
+    ...overrides,
+  }
+
+  return {
+    type: 'checkout.updated',
+    timestamp: now,
+    data: {
+      id: checkout.checkoutId,
+      created_at: now,
+      modified_at: null,
+      custom_field_data: {},
+      payment_processor: 'stripe',
+      status: checkout.status,
+      client_secret: 'checkout-client-secret',
+      url: 'https://sandbox.polar.sh/checkout/checkout-50',
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+      success_url: 'https://wepaint.test?purchase=success',
+      return_url: 'https://wepaint.test?purchase=cancelled',
+      embed_origin: null,
+      amount: checkout.amount,
+      discount_amount: 0,
+      net_amount: checkout.amount,
+      tax_amount: 0,
+      tax_behavior: 'inclusive',
+      total_amount: checkout.amount,
+      currency: checkout.currency,
+      allow_trial: false,
+      active_trial_interval: null,
+      active_trial_interval_count: null,
+      trial_end: null,
+      organization_id: 'polar-organization',
+      product_id: checkout.productId,
+      product_price_id: null,
+      discount_id: null,
+      allow_discount_codes: false,
+      require_billing_address: false,
+      is_discount_applicable: true,
+      is_free_product_price: false,
+      is_payment_required: true,
+      is_payment_setup_required: false,
+      is_payment_form_required: true,
+      customer_id: null,
+      is_business_customer: false,
+      customer_name: null,
+      customer_email: 'polar-test@example.com',
+      customer_ip_address: null,
+      customer_billing_name: null,
+      customer_billing_address: null,
+      customer_tax_id: null,
+      payment_processor_metadata: {},
+      billing_address_fields: {
+        country: 'required',
+        state: 'optional',
+        city: 'optional',
+        postal_code: 'required',
+        line1: 'optional',
+        line2: 'optional',
+      },
+      trial_interval: null,
+      trial_interval_count: null,
+      metadata: {},
+      external_customer_id: checkout.externalCustomerId,
+      products: [],
+      product: null,
+      product_price: null,
+      prices: null,
+      discount: null,
+      subscription_id: null,
+      attached_custom_fields: [],
+      customer_metadata: {},
+    },
+  }
+}
+
+async function createWebhookHeaders(
+  body: string,
+  options: {
+    secret?: string
+    timestamp?: Date
+    webhookId?: string
+  } = {}
+) {
+  const secret = options.secret ?? webhookSecret
+  const timestamp = options.timestamp ?? new Date()
+  const webhookId = options.webhookId ?? 'polar-delivery-1'
+  const timestampSeconds = Math.floor(timestamp.getTime() / 1000).toString()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(`${webhookId}.${timestampSeconds}.${body}`)
+  )
+  const encodedSignature = btoa(String.fromCharCode(...new Uint8Array(signature)))
+
+  return {
+    'content-type': 'application/json',
+    'webhook-id': webhookId,
+    'webhook-timestamp': timestampSeconds,
+    'webhook-signature': `v1,${encodedSignature}`,
+  }
+}
+
+async function deliverWebhook(
+  t: ReturnType<typeof createTestBackend>,
+  event: unknown,
+  options: Parameters<typeof createWebhookHeaders>[1] = {}
+) {
+  const body = typeof event === 'string' ? event : JSON.stringify(event)
+  return await t.fetch('/webhooks/polar', {
+    method: 'POST',
+    headers: await createWebhookHeaders(body, options),
+    body,
+  })
+}
+
 beforeEach(() => {
   vi.stubEnv('POLAR_PRODUCT_ID_50', 'polar-product-50')
   vi.stubEnv('POLAR_PRODUCT_ID_125', 'polar-product-125')
   vi.stubEnv('POLAR_API_KEY', 'polar-api-key')
+  vi.stubEnv('POLAR_WEBHOOK_SECRET', webhookSecret)
   vi.stubEnv('POLAR_API_BASE_URL', 'https://sandbox-api.polar.sh')
   vi.stubEnv('SITE_URL', 'https://wepaint.test')
 })
@@ -369,5 +512,169 @@ describe('server-authoritative Polar token packages', () => {
     expect(state.user?.tokens).toBe(3)
     expect(state.otherUser?.tokens).toBe(3)
     expect(state.transactions).toHaveLength(0)
+  })
+})
+
+describe('Polar webhook security and delivery handling', () => {
+  test('fails closed when the webhook secret is missing', async () => {
+    const t = createTestBackend()
+    vi.stubEnv('POLAR_WEBHOOK_SECRET', undefined)
+
+    const response = await t.fetch('/webhooks/polar', {
+      method: 'POST',
+      headers: {
+        'webhook-id': 'missing-secret-delivery',
+        'webhook-timestamp': Math.floor(Date.now() / 1000).toString(),
+        'webhook-signature': 'v1,empty-secret-signature',
+      },
+      body: '{}',
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.text()).toBe('Unauthorized')
+  })
+
+  test('rejects invalid signatures without logging sensitive request data', async () => {
+    const t = createTestBackend()
+    const body = JSON.stringify({ private: 'full-payload-marker' })
+    const headers = await createWebhookHeaders(body, { secret: 'wrong-webhook-secret' })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const response = await t.fetch('/webhooks/polar', {
+      method: 'POST',
+      headers: {
+        ...headers,
+        authorization: 'Bearer private-authorization-marker',
+      },
+      body,
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.text()).toBe('Unauthorized')
+    const logged = JSON.stringify([...warn.mock.calls, ...error.mock.calls])
+    expect(logged).not.toContain('full-payload-marker')
+    expect(logged).not.toContain('private-authorization-marker')
+    expect(logged).not.toContain(headers['webhook-signature'])
+    expect(logged).not.toContain(webhookSecret)
+  })
+
+  test('rejects an expired signed delivery before processing it', async () => {
+    const t = createTestBackend()
+    const response = await deliverWebhook(t, '{"not":"processed"}', {
+      timestamp: new Date(Date.now() - 301_000),
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.text()).toBe('Unauthorized')
+  })
+
+  test('returns a generic bad request for a signed malformed event', async () => {
+    const t = createTestBackend()
+    const response = await deliverWebhook(t, {
+      type: 'checkout.updated',
+      timestamp: new Date().toISOString(),
+      data: { id: 'malformed-checkout', private: 'do-not-return' },
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe('Bad Request')
+  })
+
+  test('completes and credits a valid signed checkout atomically', async () => {
+    const t = createTestBackend()
+    const userId = await seedUser(t, identity.subject, 'polar-test@example.com')
+    await t.mutation(internal.polarWebhook.createPendingPurchase, {
+      userId,
+      checkoutId: 'checkout-50',
+      packageKey: '50_tokens',
+    })
+
+    const response = await deliverWebhook(t, checkoutUpdatedEvent(userId))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('OK')
+    const state = await t.run(async (ctx) => ({
+      user: await ctx.db.get(userId),
+      purchase: await ctx.db
+        .query('polarPurchases')
+        .withIndex('by_checkout', (q) => q.eq('checkoutId', 'checkout-50'))
+        .unique(),
+      transactions: await ctx.db.query('tokenTransactions').collect(),
+    }))
+    expect(state.user?.tokens).toBe(53)
+    expect(state.purchase?.status).toBe('completed')
+    expect(state.transactions).toHaveLength(1)
+  })
+
+  test('treats duplicate signed deliveries idempotently', async () => {
+    const t = createTestBackend()
+    const userId = await seedUser(t, identity.subject, 'polar-test@example.com')
+    await t.mutation(internal.polarWebhook.createPendingPurchase, {
+      userId,
+      checkoutId: 'checkout-50',
+      packageKey: '50_tokens',
+    })
+    const event = checkoutUpdatedEvent(userId)
+
+    const first = await deliverWebhook(t, event)
+    const duplicate = await deliverWebhook(t, event)
+
+    expect(first.status).toBe(200)
+    expect(duplicate.status).toBe(200)
+    const state = await t.run(async (ctx) => ({
+      user: await ctx.db.get(userId),
+      transactions: await ctx.db.query('tokenTransactions').collect(),
+    }))
+    expect(state.user?.tokens).toBe(53)
+    expect(state.transactions).toHaveLength(1)
+  })
+
+  test('leaves a purchase pending after transient processing failure and succeeds on retry', async () => {
+    const t = createTestBackend()
+    const userId = await seedUser(
+      t,
+      identity.subject,
+      'polar-test@example.com',
+      Number.MAX_SAFE_INTEGER - 10
+    )
+    await t.mutation(internal.polarWebhook.createPendingPurchase, {
+      userId,
+      checkoutId: 'checkout-50',
+      packageKey: '50_tokens',
+    })
+    const event = checkoutUpdatedEvent(userId)
+
+    const failed = await deliverWebhook(t, event)
+    expect(failed.status).toBe(500)
+    const afterFailure = await t.run(async (ctx) => ({
+      user: await ctx.db.get(userId),
+      purchase: await ctx.db
+        .query('polarPurchases')
+        .withIndex('by_checkout', (q) => q.eq('checkoutId', 'checkout-50'))
+        .unique(),
+      transactions: await ctx.db.query('tokenTransactions').collect(),
+    }))
+    expect(afterFailure.user?.tokens).toBe(Number.MAX_SAFE_INTEGER - 10)
+    expect(afterFailure.purchase?.status).toBe('pending')
+    expect(afterFailure.transactions).toHaveLength(0)
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(userId, { tokens: 3 })
+    })
+    const retried = await deliverWebhook(t, event)
+
+    expect(retried.status).toBe(200)
+    const afterRetry = await t.run(async (ctx) => ({
+      user: await ctx.db.get(userId),
+      purchase: await ctx.db
+        .query('polarPurchases')
+        .withIndex('by_checkout', (q) => q.eq('checkoutId', 'checkout-50'))
+        .unique(),
+      transactions: await ctx.db.query('tokenTransactions').collect(),
+    }))
+    expect(afterRetry.user?.tokens).toBe(53)
+    expect(afterRetry.purchase?.status).toBe('completed')
+    expect(afterRetry.transactions).toHaveLength(1)
   })
 })

--- a/convex/polarWebhook.ts
+++ b/convex/polarWebhook.ts
@@ -1,6 +1,7 @@
 import { httpAction, internalMutation } from './_generated/server'
 import { v } from 'convex/values'
 import { internal } from './_generated/api'
+import { validateEvent, WebhookVerificationError } from '@polar-sh/sdk/webhooks'
 import {
   getTokenPackage,
   getTokenPackageDefinition,
@@ -9,192 +10,52 @@ import {
 } from './polarPackages'
 import { assertPositiveTokenAmount, assertValidTokenBalance } from './tokenPolicy'
 
-interface CheckoutUpdateData {
-  id: string
-  status: string
-  productId: string
-  amount: number
-  currency: string
-  externalCustomerId: string | null
-}
+const unauthorizedResponse = () => new Response('Unauthorized', { status: 401 })
+const malformedResponse = () => new Response('Bad Request', { status: 400 })
 
-function parseCheckoutUpdateData(value: unknown): CheckoutUpdateData {
-  if (!value || typeof value !== 'object') {
-    throw new Error('Invalid checkout payload')
-  }
-
-  const data = value as Record<string, unknown>
-  if (
-    typeof data.id !== 'string' ||
-    typeof data.status !== 'string' ||
-    typeof data.product_id !== 'string' ||
-    typeof data.amount !== 'number' ||
-    typeof data.currency !== 'string' ||
-    (data.external_customer_id !== null && typeof data.external_customer_id !== 'string')
-  ) {
-    throw new Error('Invalid checkout payload')
-  }
-
+function verificationHeaders(headers: Headers): Record<string, string> {
   return {
-    id: data.id,
-    status: data.status,
-    productId: data.product_id,
-    amount: data.amount,
-    currency: data.currency,
-    externalCustomerId: data.external_customer_id,
+    'webhook-id': headers.get('webhook-id') ?? '',
+    'webhook-timestamp': headers.get('webhook-timestamp') ?? '',
+    'webhook-signature': headers.get('webhook-signature') ?? '',
   }
-}
-
-// Custom webhook verification for Convex environment following Standard Webhooks spec
-async function verifyPolarWebhook(body: string, headers: Record<string, string>, secret: string) {
-  // Standard Webhooks uses these headers
-  const webhookId = headers['webhook-id'] || headers['Webhook-Id'];
-  const webhookTimestamp = headers['webhook-timestamp'] || headers['Webhook-Timestamp'];
-  const webhookSignature = headers['webhook-signature'] || headers['Webhook-Signature'];
-  
-  if (!webhookId || !webhookTimestamp || !webhookSignature) {
-    console.error('[Polar Webhook] Missing required headers:', {
-      'webhook-id': webhookId,
-      'webhook-timestamp': webhookTimestamp,
-      'webhook-signature': webhookSignature
-    });
-    throw new Error('Missing required webhook headers');
-  }
-  
-  // Try multiple secret formats
-  console.log('[Polar Webhook] Secret format check:', {
-    hasWhsecPrefix: secret.startsWith('whsec_'),
-    length: secret.length,
-    preview: secret.substring(0, 10) + '...'
-  });
-  
-  // We'll try multiple approaches for the secret
-  const encoder = new TextEncoder();
-  const secretsToTry = [];
-  
-  // 1. Raw secret as-is
-  secretsToTry.push(encoder.encode(secret));
-  
-  // 2. Secret without whsec_ prefix if present
-  if (secret.startsWith('whsec_')) {
-    const withoutPrefix = secret.slice(6);
-    secretsToTry.push(encoder.encode(withoutPrefix));
-    
-    // 3. Base64 decoded version of secret without prefix
-    try {
-      const decoded = Uint8Array.from(atob(withoutPrefix), c => c.charCodeAt(0));
-      secretsToTry.push(decoded);
-    } catch (e) {
-      console.log('[Polar Webhook] Could not base64 decode secret without prefix');
-    }
-  }
-  
-  // 4. Base64 decoded version of full secret
-  try {
-    const decoded = Uint8Array.from(atob(secret), c => c.charCodeAt(0));
-    secretsToTry.push(decoded);
-  } catch (e) {
-    console.log('[Polar Webhook] Could not base64 decode full secret');
-  }
-  
-  // Create the signed content: msg_id.timestamp.payload
-  const signedContent = `${webhookId}.${webhookTimestamp}.${body}`;
-  
-  console.log('[Polar Webhook] Signed content preview:', signedContent.substring(0, 100) + '...');
-  
-  // Try each secret format
-  let isValid = false;
-  
-  for (let i = 0; i < secretsToTry.length; i++) {
-    try {
-      const key = await crypto.subtle.importKey(
-        'raw',
-        secretsToTry[i],
-        { name: 'HMAC', hash: 'SHA-256' },
-        false,
-        ['sign']
-      );
-      
-      const signatureBytes = await crypto.subtle.sign(
-        'HMAC',
-        key,
-        encoder.encode(signedContent)
-      );
-      
-      // Convert to base64
-      const computedSignature = btoa(String.fromCharCode(...new Uint8Array(signatureBytes)));
-      const expectedSig = `v1,${computedSignature}`;
-      
-      console.log(`[Polar Webhook] Try ${i + 1} - Computed:`, expectedSig);
-      
-      // Extract signatures from header (can be space-delimited)
-      const signatures = webhookSignature.split(' ');
-      
-      for (const sig of signatures) {
-        if (sig === expectedSig) {
-          isValid = true;
-          console.log(`[Polar Webhook] Signature matched with secret format ${i + 1}`);
-          break;
-        }
-      }
-      
-      if (isValid) break;
-    } catch (e) {
-      console.log(`[Polar Webhook] Failed to compute signature with format ${i + 1}:`, e);
-    }
-  }
-  
-  if (!isValid) {
-    console.error('[Polar Webhook] Signature verification failed');
-    console.error('[Polar Webhook] Received:', webhookSignature);
-    console.error('[Polar Webhook] None of the computed signatures matched');
-    throw new Error('Invalid signature');
-  }
-  
-  // Check timestamp to prevent replay attacks (5 minute window)
-  const timestamp = parseInt(webhookTimestamp);
-  const currentTime = Math.floor(Date.now() / 1000);
-  if (Math.abs(currentTime - timestamp) > 300) {
-    throw new Error('Webhook timestamp too old');
-  }
-  
-  // Parse and return the event
-  return JSON.parse(body);
 }
 
 // Polar webhook handler
 export const handlePolarWebhook = httpAction(async (ctx, request) => {
-  // Get the raw body for signature verification
-  const rawBody = await request.text()
+  const webhookSecret = process.env.POLAR_WEBHOOK_SECRET
+  if (!webhookSecret?.trim()) {
+    console.error('[Polar Webhook] Webhook verification is not configured')
+    return unauthorizedResponse()
+  }
+
+  let event: ReturnType<typeof validateEvent>
+  try {
+    const rawBody = await request.text()
+    event = validateEvent(rawBody, verificationHeaders(request.headers), webhookSecret)
+  } catch (error) {
+    if (error instanceof WebhookVerificationError) {
+      console.warn('[Polar Webhook] Webhook verification failed')
+      return unauthorizedResponse()
+    }
+    console.warn('[Polar Webhook] Malformed webhook event rejected')
+    return malformedResponse()
+  }
 
   try {
-    // Parse headers into a plain object
-    const headers: Record<string, string> = {}
-    request.headers.forEach((value, key) => {
-      headers[key] = value
-    })
-
-    // Log all headers for debugging
-    console.log('[Polar Webhook] Received headers:', headers)
-
-    // Verify webhook signature and parse the event
-    const event = await verifyPolarWebhook(rawBody, headers, process.env.POLAR_WEBHOOK_SECRET || '')
-
-    console.log('[Polar Webhook] Received event:', event)
-
-    const { type, data } = event
-
-    if (type === 'checkout.created') {
-      // Just log and acknowledge - purchase record already created in polar.ts
-      console.log('[Polar Webhook] Checkout created:', data.id)
+    if (event.type === 'checkout.created') {
       return new Response('OK', { status: 200 })
     }
 
-    if (type === 'checkout.updated') {
-      const checkoutData = parseCheckoutUpdateData(data)
+    if (event.type === 'checkout.updated') {
+      const checkoutData = event.data
 
       if (checkoutData.status !== 'succeeded' && checkoutData.status !== 'confirmed') {
         return new Response('OK', { status: 200 })
+      }
+
+      if (!checkoutData.productId) {
+        return malformedResponse()
       }
 
       const result = await ctx.runMutation(internal.polarWebhook.validateAndCompletePurchase, {
@@ -214,18 +75,9 @@ export const handlePolarWebhook = httpAction(async (ctx, request) => {
       return new Response('OK', { status: 200 })
     }
 
-    // Unknown event type
-    console.log('[Polar Webhook] Unhandled event type:', type)
     return new Response('OK', { status: 200 })
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.message.includes('signature') || error.message.includes('Invalid signature'))
-    ) {
-      console.error('[Polar Webhook] Verification failed:', error.message)
-      return new Response('Unauthorized', { status: 401 })
-    }
-    console.error('[Polar Webhook] Error processing webhook:', error)
+  } catch {
+    console.error('[Polar Webhook] Webhook processing failed')
     return new Response('Internal Server Error', { status: 500 })
   }
 })

--- a/docs/POLAR_SETUP.md
+++ b/docs/POLAR_SETUP.md
@@ -78,11 +78,22 @@ currency. Discount codes are disabled for these checkout sessions.
 
 ## Webhook Security
 
-The webhook handler verifies signatures to ensure requests are from Polar:
+The webhook handler uses Polar SDK's supported event verifier before running any
+purchase logic:
 
-- In production (when `POLAR_WEBHOOK_SECRET` is set), all webhook requests are verified
-- Invalid signatures return a 401 Unauthorized response
-- The signature is verified using HMAC-SHA256
+- `POLAR_WEBHOOK_SECRET` is required in every Convex deployment. If it is
+  missing or blank, all deliveries fail closed with `401 Unauthorized`.
+- Set the exact value issued by Polar for that webhook endpoint. Do not add or
+  remove a prefix and do not base64-decode it.
+- Sandbox and production webhook endpoints have separate secrets; configure the
+  matching value in each Convex deployment.
+- Signature and timestamp verification follows Standard Webhooks with a
+  five-minute timestamp tolerance. Expired, future-dated, missing-header, and
+  invalid-signature deliveries return a generic 401 before business logic.
+- Signed events that do not match Polar's event schema return a generic 400.
+  Transient processing failures return 500 so Polar can retry the delivery.
+- Do not log webhook secrets, signatures, authorization/request headers, or
+  event payloads while troubleshooting.
 
 ## Troubleshooting
 

--- a/docs/SECURITY_PERFORMANCE_AUDIT.md
+++ b/docs/SECURITY_PERFORMANCE_AUDIT.md
@@ -80,10 +80,12 @@ This document tracks the repository audit findings so work can continue across s
 
 ### AUD-003: Fail closed and sanitize Polar webhook handling
 
-- Status: TODO
+- Status: DONE
 - Area: Payments / Secrets
 - Files:
   - `convex/polarWebhook.ts`
+  - `convex/polar.test.ts`
+  - `docs/POLAR_SETUP.md`
 - Problem: Missing `POLAR_WEBHOOK_SECRET` falls back to an empty HMAC key. Logs also expose headers, computed signatures, event bodies, and a secret prefix.
 - Required changes:
   - Reject requests or deployment initialization when the webhook secret is missing.
@@ -95,8 +97,10 @@ This document tracks the repository audit findings so work can continue across s
   - No sensitive signature or secret material appears in logs.
   - A transient credit failure does not permanently mark a purchase completed.
   - Timestamp and replay protections are tested.
-- Verification: Not run
-- Notes:
+- Verification: `corepack pnpm test:run` PASS (2 files, 21 tests); targeted Polar webhook suite PASS (17 tests); `corepack pnpm typecheck` PASS; targeted ESLint PASS with 0 errors or warnings; targeted Prettier check PASS; `corepack pnpm build` PASS with the pre-existing large-chunk warning; `corepack pnpm audit --prod` PASS with no known vulnerabilities.
+- Notes: Completed 2026-07-09. Replaced the custom multi-format HMAC implementation with Polar SDK's supported `validateEvent` verifier, which applies the Standard Webhooks five-minute timestamp tolerance, constant-time signature verification, JSON parsing, and Polar event schema validation before business logic. Missing or whitespace-only `POLAR_WEBHOOK_SECRET` values fail closed, verification failures return a generic 401, signed malformed events return a generic 400, and processing failures return a generic 500 so Polar can retry. Webhook logs now contain fixed operational messages only; secrets, prefixes, signatures, authorization/request headers, signed content, and event payloads are never logged. The AUD-002 `validateAndCompletePurchase` internal mutation remains the single atomic transaction for package validation, balance credit, transaction insertion, and purchase completion. Tests cover missing configuration, invalid signatures, expired timestamps, malformed events, successful completion, duplicate delivery, sensitive-log redaction, and a transient mutation failure followed by successful retry, in addition to the AUD-002 product/amount/currency/customer/package validation cases.
+
+  Deployment/configuration: set `POLAR_WEBHOOK_SECRET` in every Convex deployment to the exact secret issued for that deployment's Polar webhook endpoint; sandbox and production endpoints require their own secrets. Do not add prefixes, decode the value, or expose it through a `VITE_` variable. Keep the AUD-002 `POLAR_PRODUCT_ID_50`, `POLAR_PRODUCT_ID_125`, `POLAR_API_KEY`, `POLAR_API_BASE_URL`, and `SITE_URL` values configured as documented in `docs/POLAR_SETUP.md`, and deploy the Convex functions after configuration. A missing secret intentionally causes every delivery to return 401. No deployment was performed as part of this change.
 
 ### AUD-004: Enforce authorization on every Convex function
 


### PR DESCRIPTION
## Summary

- replace the custom multi-format HMAC verifier with Polar SDK's supported `validateEvent` flow
- fail closed when `POLAR_WEBHOOK_SECRET` is missing and return generic 401/400/500 responses
- remove secret, signature, header, signed-content, and webhook-payload logging
- preserve AUD-002's single atomic, idempotent purchase completion mutation
- add HTTP-route coverage for missing secret, invalid signature, expired timestamp, malformed event, successful completion, duplicate delivery, and transient processing failure
- mark AUD-003 DONE and document required Polar/Convex configuration

## Root cause

The webhook route fell back to an empty HMAC key, tried several undocumented secret encodings, logged sensitive verification inputs, and previously risked separating purchase completion from token crediting.

## Impact

Webhook authentication now uses Polar's supported Standard Webhooks implementation. Timestamp and signature verification plus Polar schema validation complete before business logic. Verification and malformed-payload responses do not leak request details, and processing failures remain retryable without leaving purchases partially completed.

This remains compatible with the server-authoritative product, amount, currency, customer, and package validation introduced by AUD-002.

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm test:run` — 2 files, 21 tests passed
- targeted Polar suite — 17 tests passed
- targeted ESLint — 0 errors or warnings
- targeted Prettier check — passed
- `corepack pnpm build` — passed with the pre-existing large-chunk warning
- `corepack pnpm audit --prod` — no known vulnerabilities

## Configuration

Set the exact Polar-issued `POLAR_WEBHOOK_SECRET` independently in every sandbox and production Convex deployment. Keep the AUD-002 product IDs, API key/base URL, and `SITE_URL` configured as documented. Deploy the Convex functions after configuration.

No deployment was performed.
