### PR TITLE
ui: restore token purchase modal

### DIFF
--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -1122,6 +1122,11 @@ export function PaintingView() {
           connectionStatus={connectionStatus}
         />
       )}
+      <TokenDisplay
+        className={`absolute right-4 z-40 rounded-lg bg-white/90 px-3 py-2 text-gray-900 shadow backdrop-blur-sm ${
+          adminFeaturesEnabled ? 'top-24' : 'top-4'
+        }`}
+      />
       {adminFeaturesEnabled && (
         <SessionInfo
           sessionId={sessionId}


### PR DESCRIPTION
## Summary

- render the existing authenticated token display in `PaintingView`
- restore the purchase-modal target used by AI and merge dialogs
- position the token balance away from the admin profile when admin controls are enabled

## Root cause

The AI and merge dialogs close themselves and click the element marked with `data-token-buy-more`. `TokenDisplay` was imported but never rendered, so that selector returned `null`; the originating modal closed and no checkout action ran.

## Verification

- `corepack pnpm test:run` — PASS (2 files, 14 tests)
- `corepack pnpm typecheck` — PASS
- `corepack pnpm build` — PASS (existing large-chunk warning only)
- targeted ESLint — PASS with 0 errors and 42 pre-existing `PaintingView` warnings
- `git diff --check` — PASS

No deployment was performed. After merge, the frontend needs to be rebuilt and restarted; the already-deployed Convex checkout functions do not need another backend deployment for this UI-only fix.
