### PR TITLE
Fix invisible strokes on new paint layers above images

### DIFF
--- a/convex/paintLayers.ts
+++ b/convex/paintLayers.ts
@@ -45,15 +45,30 @@ export const createPaintLayer = mutation({
     name: v.string(),
   },
   handler: async (ctx, args) => {
-    // Get the highest layer order to put new layer on top
+    // Get the highest layer order across ALL layer types (paint, uploaded, AI)
+    // so the new layer lands on top of images too, not just other paint layers
     const existingLayers = await ctx.db
       .query("paintLayers")
       .withIndex("by_session", (q) => q.eq("sessionId", args.sessionId))
       .collect();
-    
-    const maxOrder = existingLayers.reduce((max, layer) => 
+    const uploadedImages = await ctx.db
+      .query("uploadedImages")
+      .withIndex("by_session", (q) => q.eq("sessionId", args.sessionId))
+      .collect();
+    const aiImages = await ctx.db
+      .query("aiGeneratedImages")
+      .withIndex("by_session", (q) => q.eq("sessionId", args.sessionId))
+      .collect();
+
+    let maxOrder = existingLayers.reduce((max, layer) =>
       Math.max(max, layer.layerOrder), -1
     );
+    uploadedImages.forEach(img => {
+      maxOrder = Math.max(maxOrder, img.layerOrder);
+    });
+    aiImages.forEach(img => {
+      maxOrder = Math.max(maxOrder, img.layerOrder);
+    });
     
     // Create the new paint layer
     const layerId = await ctx.db.insert("paintLayers", {

--- a/src/components/KonvaCanvas.tsx
+++ b/src/components/KonvaCanvas.tsx
@@ -1348,7 +1348,9 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
         {/* Content layers render first; transformer should be above them */}
         {/* Render layers in order */}
         {layers
-          .sort((a, b) => a.order - b.order)
+          // On equal order (legacy data), render paint layers above images to
+          // match the layers panel, which lists paint layers on top for ties
+          .sort((a, b) => (a.order - b.order) || ((a.type === 'paint' ? 1 : 0) - (b.type === 'paint' ? 1 : 0)))
           .map((layer, renderIndex) => {
             if (!layer.visible) return null
             


### PR DESCRIPTION
## What

Fixes the bug where painting on a newly created paint layer that sits above an image layer produced no visible strokes.

## Why

Layer orders were assigned from two disjoint views of the session:

- Image uploads (`convex/images.ts`) pick `max(session paint order, image orders) + 1` — ignoring the `paintLayers` table.
- `createPaintLayer` (`convex/paintLayers.ts`) picked `max + 1` over paint layers only — ignoring images.

In the common flow (default paint layer at order 0 → upload an image → order 1 → create a paint layer → also order 1), the new paint layer and the image collided on the same order. The tie then broke inconsistently: the layers panel (descending stable sort) displayed the paint layer on top, while the canvas (ascending stable sort) rendered it **below** the image. Strokes were saved correctly but painted behind the image — invisible.

## Changes

- `createPaintLayer` now computes the max order across paint layers, uploaded images, and AI images, so new paint layers genuinely land on top.
- `KonvaCanvas` breaks order ties by rendering paint layers above images, matching the panel's display and fixing sessions that already contain collided orders.

## Notes for reviewers

- `pnpm typecheck` passes (app + convex). No test runner is configured.
- The Convex mutation change needs `npx convex deploy` to reach production; the PR preview runs against the live backend so only the canvas tie-break is visible there.
- Pre-existing related wart, not addressed here: `mergeDown` renumbers paint layers from 0 ignoring image orders, which can reintroduce collisions (now masked by the render tie-break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)