### PR TITLE
Surface silent save failures with a sync banner and stroke replay

### DIFF
--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -6,6 +6,7 @@ import { type BrushSettings } from './BrushSettingsModal'
 import { AdminPanel } from './AdminPanel' // Import AdminPanel
 import { SessionInfo } from './SessionInfo'
 import { PresenceStrip } from './PresenceStrip'
+import { SyncStatusBanner } from './SyncStatusBanner'
 import { P2PStatus } from './P2PStatus'
 import { P2PDebugPanel } from './P2PDebugPanel'
 import { ImageUploadModal } from './ImageUploadModal'
@@ -1113,6 +1114,8 @@ export function PaintingView() {
           ))}
         </div>
       )}
+      {/* Persistent "changes aren't saving" banner (auth expiry / network) */}
+      <SyncStatusBanner />
       {/* Presence strip + connection indicator — visible to all users */}
       {validSessionId && (
         <PresenceStrip

--- a/src/components/SyncStatusBanner.tsx
+++ b/src/components/SyncStatusBanner.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from 'react'
+import { useConvexAuth } from 'convex/react'
+import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
+import { useAuthState, authClient } from '../lib/auth-client'
+import { useSyncStatus, retrySync } from '../lib/syncStatus'
+
+/**
+ * Grace period before flagging the "Better Auth signed in but Convex not
+ * authenticated" desync — token refresh after page load can legitimately take
+ * a few seconds.
+ */
+const DESYNC_GRACE_MS = 8000
+
+/**
+ * Persistent, non-intrusive banner shown when changes stop saving: either a
+ * mutation failed (reported via the syncStatus store) or the session JWT
+ * expired, leaving Better Auth signed in while Convex is unauthenticated —
+ * the state previously only visible in the dev-only AuthDebug box.
+ */
+export function SyncStatusBanner() {
+  const sync = useSyncStatus()
+  const { isLoaded, isSignedIn } = useAuthState()
+  const { isAuthenticated, isLoading } = useConvexAuth()
+  const [signingIn, setSigningIn] = useState(false)
+
+  // Detect the auth desync only after it has persisted past the grace period.
+  const desyncCandidate = isLoaded && isSignedIn && !isLoading && !isAuthenticated
+  const [desynced, setDesynced] = useState(false)
+  useEffect(() => {
+    if (!desyncCandidate) {
+      setDesynced(false)
+      return
+    }
+    const timer = setTimeout(() => setDesynced(true), DESYNC_GRACE_MS)
+    return () => clearTimeout(timer)
+  }, [desyncCandidate])
+
+  // When Convex auth comes back (e.g. after re-sign-in), replay queued strokes.
+  const wasAuthenticatedRef = useRef(isAuthenticated)
+  useEffect(() => {
+    if (isAuthenticated && !wasAuthenticatedRef.current && sync.status === 'error') {
+      void retrySync()
+    }
+    wasAuthenticatedRef.current = isAuthenticated
+  }, [isAuthenticated, sync.status])
+
+  if (import.meta.env.VITE_AUTH_DISABLED === 'true') return null
+
+  const visible = sync.status === 'error' || desynced
+  if (!visible) return null
+
+  const isAuthIssue = desynced || sync.kind === 'auth'
+  const detail = isAuthIssue
+    ? 'Your session expired — sign in again to keep saving.'
+    : sync.kind === 'network'
+      ? 'Connection lost — your changes will retry once you reconnect.'
+      : 'Something went wrong while saving.'
+
+  const handleSignInAgain = async () => {
+    setSigningIn(true)
+    try {
+      // Round-trip through Google to mint a fresh Convex JWT, then land back
+      // on this painting so no work is lost.
+      const result = await authClient.signIn.social({
+        provider: 'google',
+        callbackURL: window.location.pathname + window.location.search,
+      })
+      if (result.error) setSigningIn(false)
+      // On success the browser navigates away; leave the spinner running.
+    } catch {
+      setSigningIn(false)
+    }
+  }
+
+  return (
+    <div
+      role="alert"
+      className="absolute top-2 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-lg border border-amber-300 bg-amber-50/95 px-3 py-2 text-amber-900 shadow-lg backdrop-blur-sm max-w-[calc(100%-1rem)]"
+    >
+      <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600" />
+      <div className="text-xs leading-snug">
+        <span className="font-semibold">Changes aren&apos;t saving.</span>{' '}
+        <span className="hidden sm:inline">{detail}</span>
+        {sync.pendingStrokeCount > 0 && (
+          <span>
+            {' '}
+            {sync.pendingStrokeCount} stroke{sync.pendingStrokeCount === 1 ? '' : 's'} waiting to sync.
+          </span>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {isAuthIssue && isSignedIn && (
+          <button
+            type="button"
+            onClick={handleSignInAgain}
+            disabled={signingIn}
+            className="flex items-center gap-1 rounded bg-amber-600 px-2 py-1 text-xs font-medium text-white hover:bg-amber-700 disabled:opacity-60"
+          >
+            {signingIn && <Loader2 className="h-3 w-3 animate-spin" />}
+            Sign in again
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => void retrySync()}
+          disabled={sync.retrying}
+          className="flex items-center gap-1 rounded border border-amber-400 px-2 py-1 text-xs font-medium hover:bg-amber-100 disabled:opacity-60"
+        >
+          {sync.retrying ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+          Retry
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/usePaintingSession.ts
+++ b/src/hooks/usePaintingSession.ts
@@ -4,6 +4,7 @@ import { Id } from "../../convex/_generated/dataModel";
 import { useCallback, useEffect, useState, useRef, useMemo } from "react";
 import { p2pLogger } from "../lib/p2p-logger";
 import { convexLow } from "../lib/convex";
+import { reportSyncFailure, reportSyncSuccess } from "../lib/syncStatus";
 import {
   generateGuestKey,
   getGuestKey,
@@ -281,8 +282,8 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
     if (!sessionId) return;
     
     console.log('[usePaintingSession] Adding stroke with isEraser:', isEraser, 'layerId:', layerId, 'colorMode:', colorMode);
-    
-    const strokeId = await addStroke({
+
+    const strokeArgs = {
       sessionId,
       layerId: layerId ? (layerId as Id<"paintLayers"> | Id<"uploadedImages"> | Id<"aiGeneratedImages">) : undefined,
       userId: currentUser.id || undefined,  // Allow undefined for guest users
@@ -294,9 +295,19 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
       isEraser,
       colorMode,
       guestKey: localGuestKey || undefined,
-    });
-    
-    return strokeId;
+    };
+
+    try {
+      const strokeId = await addStroke(strokeArgs);
+      reportSyncSuccess();
+      return strokeId;
+    } catch (e) {
+      // Queue the stroke for replay after re-auth/reconnect and surface the
+      // failure via the sync banner instead of failing silently.
+      console.error('[usePaintingSession] Failed to save stroke:', e);
+      reportSyncFailure(e, strokeArgs);
+      return undefined;
+    }
   }, [sessionId, addStroke, currentUser, localGuestKey]);
 
   // Stable per-browser id used to key guest presence records (guests have no userId)
@@ -348,8 +359,11 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
       if (pendingPresenceRef.current === payload) {
         pendingPresenceRef.current = null;
       }
+      reportSyncSuccess();
     } catch (e) {
-      // ignore
+      // Presence is best-effort, but a failure here is the same auth/network
+      // problem that breaks stroke saving — surface it via the sync banner.
+      reportSyncFailure(e);
     } finally {
       presenceInFlightRef.current = false;
     }
@@ -426,15 +440,31 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
   // Undo the last stroke
   const undoLastStroke = useCallback(async () => {
     if (!sessionId) return false;
-    
-    return await removeLastStroke({ sessionId, guestKey: localGuestKey || undefined });
+
+    try {
+      const result = await removeLastStroke({ sessionId, guestKey: localGuestKey || undefined });
+      reportSyncSuccess();
+      return result;
+    } catch (e) {
+      console.error('[usePaintingSession] Failed to undo stroke:', e);
+      reportSyncFailure(e);
+      return false;
+    }
   }, [sessionId, removeLastStroke, localGuestKey]);
 
   // Redo the last undone stroke
   const redoLastStroke = useCallback(async () => {
     if (!sessionId) return false;
-    
-    return await restoreLastDeletedStroke({ sessionId, guestKey: localGuestKey || undefined });
+
+    try {
+      const result = await restoreLastDeletedStroke({ sessionId, guestKey: localGuestKey || undefined });
+      reportSyncSuccess();
+      return result;
+    } catch (e) {
+      console.error('[usePaintingSession] Failed to redo stroke:', e);
+      reportSyncFailure(e);
+      return false;
+    }
   }, [sessionId, restoreLastDeletedStroke, localGuestKey]);
 
   // Throttle live stroke updates to reduce lag
@@ -479,7 +509,7 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
         opacity,
         colorMode,
         guestKey: localGuestKey || undefined,
-      });
+      }).catch((e) => reportSyncFailure(e));
       pendingLiveStrokeRef.current = null;
       
       // Clear any pending timeout since we just updated
@@ -512,7 +542,7 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
           opacity: pending.opacity,
           colorMode: pending.colorMode,
           guestKey: localGuestKey || undefined,
-        });
+        }).catch((e) => reportSyncFailure(e));
         pendingLiveStrokeRef.current = null;
       }
       liveStrokeUpdateRef.current = null;

--- a/src/lib/syncStatus.ts
+++ b/src/lib/syncStatus.ts
@@ -1,0 +1,139 @@
+import { useSyncExternalStore } from "react";
+import type { FunctionArgs } from "convex/server";
+import { api } from "../../convex/_generated/api";
+import { convexHigh } from "./convex";
+
+/**
+ * Module-level sync failure store shared by every usePaintingSession instance
+ * (PaintingView and KonvaCanvas each call the hook) and the SyncStatusBanner.
+ *
+ * When a mutation fails — most importantly after a Better Auth JWT expires
+ * mid-session, which makes the backend throw "Unauthorized" — the failure is
+ * reported here instead of vanishing in an unhandled promise rejection. Failed
+ * strokes are retained so a successful re-auth can replay them.
+ */
+
+export type SyncErrorKind = "auth" | "network" | "unknown";
+
+export interface SyncStatus {
+  status: "ok" | "error";
+  kind: SyncErrorKind;
+  /** Strokes that failed to save and are queued for replay. */
+  pendingStrokeCount: number;
+  retrying: boolean;
+}
+
+type AddStrokeArgs = FunctionArgs<typeof api.strokes.addStroke>;
+
+// Cap the replay queue so a long offline stretch can't grow memory unboundedly.
+const MAX_PENDING_STROKES = 100;
+
+let pendingStrokes: AddStrokeArgs[] = [];
+let state: SyncStatus = {
+  status: "ok",
+  kind: "unknown",
+  pendingStrokeCount: 0,
+  retrying: false,
+};
+
+const listeners = new Set<() => void>();
+
+function setState(partial: Partial<SyncStatus>) {
+  state = { ...state, ...partial, pendingStrokeCount: pendingStrokes.length };
+  listeners.forEach((l) => l());
+}
+
+/**
+ * Distinguish auth failures from transient network errors. Backend auth
+ * checks throw "Unauthorized" / "Not authenticated"; anything failing while
+ * the websocket is down is treated as a network problem.
+ */
+export function classifySyncError(error: unknown): SyncErrorKind {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/unauthorized|unauthenticated|not authenticated|token|jwt/i.test(message)) {
+    return "auth";
+  }
+  try {
+    if (!convexHigh.connectionState().isWebSocketConnected) {
+      return "network";
+    }
+  } catch {
+    // connectionState is best-effort; fall through to unknown
+  }
+  return "unknown";
+}
+
+/** Record a failed mutation; optionally retain the stroke args for replay. */
+export function reportSyncFailure(error: unknown, failedStroke?: AddStrokeArgs) {
+  if (failedStroke) {
+    pendingStrokes.push(failedStroke);
+    if (pendingStrokes.length > MAX_PENDING_STROKES) {
+      pendingStrokes = pendingStrokes.slice(-MAX_PENDING_STROKES);
+    }
+  }
+  const kind = classifySyncError(error);
+  // Don't let a later vague error mask a known auth failure.
+  const nextKind = state.status === "error" && state.kind === "auth" && kind === "unknown" ? "auth" : kind;
+  setState({ status: "error", kind: nextKind });
+}
+
+/**
+ * Record a successful mutation. Clears the error banner and, if strokes are
+ * still queued from the outage, kicks off a replay.
+ */
+export function reportSyncSuccess() {
+  if (state.status === "ok" && pendingStrokes.length === 0) return;
+  if (pendingStrokes.length > 0) {
+    void retrySync();
+  } else {
+    setState({ status: "ok" });
+  }
+}
+
+/**
+ * Replay queued strokes in order via the singleton Convex client. With an
+ * empty queue, probes the backend so "Retry" gives real feedback either way.
+ * Returns true when everything went through.
+ */
+export async function retrySync(): Promise<boolean> {
+  if (state.retrying) return false;
+  setState({ retrying: true });
+  try {
+    while (pendingStrokes.length > 0) {
+      const stroke = pendingStrokes[0];
+      await convexHigh.mutation(api.strokes.addStroke, stroke);
+      pendingStrokes.shift();
+      setState({});
+    }
+    if (state.status === "error") {
+      // Nothing queued to prove the connection works — probe with a query.
+      await convexHigh.query(api.auth.getCurrentUser, {});
+    }
+    setState({ status: "ok" });
+    return true;
+  } catch (error) {
+    setState({ status: "error", kind: classifySyncError(error) });
+    return false;
+  } finally {
+    setState({ retrying: false });
+  }
+}
+
+/** Drop queued strokes (e.g. when the user clears the canvas). */
+export function discardPendingStrokes() {
+  pendingStrokes = [];
+  setState({});
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): SyncStatus {
+  return state;
+}
+
+export function useSyncStatus(): SyncStatus {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
## What

Fixes UX audit item O3 (major): when a signed-in user's session/JWT expired while painting, stroke and presence mutations silently started failing — the user kept drawing, believing work was saved.

- **New `src/lib/syncStatus.ts`** — module-level sync store shared by both `usePaintingSession` instances (PaintingView and KonvaCanvas) and the banner. Classifies failures as `auth` (Unauthorized / token messages, i.e. expired JWT), `network` (websocket down), or `unknown`. Failed strokes are retained in a replay queue (capped at 100); `retrySync()` replays them in order via the singleton Convex client, or probes `auth.getCurrentUser` when the queue is empty so Retry gives real feedback.
- **New `src/components/SyncStatusBanner.tsx`** — persistent, non-intrusive top-center banner ("Changes aren't saving…") with pending-stroke count, a **Retry** CTA, and a **Sign in again** CTA for auth failures that round-trips through Google with `callbackURL` set to the current painting URL. It also detects the "Better Auth signed in but Convex not authenticated" desync in production (previously only visible in the dev-only AuthDebug box), after an 8s grace period for normal token refresh.
- **`usePaintingSession.ts`** — stroke add, undo, redo, presence flush (previously `catch { /* ignore */ }`), and fire-and-forget live-stroke updates now report failures instead of failing silently. Failed strokes are queued with their exact args. Any subsequent successful mutation (e.g. the 20s presence heartbeat) or restored Convex auth clears the banner and auto-replays the queue.

## Why

Silent data loss is the worst failure mode for a drawing app — the local canvas keeps rendering optimistic strokes, so nothing looked wrong while nothing was being saved.

## Verification

- `pnpm typecheck` passes (app + convex).
- In `pnpm dev` with the local backend, injected an `Unauthorized` throw into stroke saving and drew on the canvas: failure was caught and queued, banner appeared, and the next successful presence heartbeat auto-replayed the strokes — confirmed persisted after a page reload.
- Queued a backend-rejected stroke to confirm the persistent case: banner stayed up with "1 stroke waiting to sync" and failed retries kept it visible.

## Notes for reviewers

- Convex queues (rather than rejects) mutations while the websocket is down, so pure network blips mostly self-heal without the banner; the banner primarily catches server-side rejections — exactly the expired-JWT case.
- `addStrokeToSession` now resolves `undefined` on failure; both KonvaCanvas call sites already guard with `if (strokeId)`.
- The desync-detection path uses the same logic as AuthDebug but wasn't live-tested (needs a real Google session expiring) — worth watching after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)