### PR TITLE
security: authorize library thumbnail updates

### DIFF
--- a/convex/liveStrokes.ts
+++ b/convex/liveStrokes.ts
@@ -1,6 +1,6 @@
 import { mutation, query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
-import { assertCanModifySession } from "./strokes";
+import { assertCanModifySession } from "./sessionAuth";
 
 /**
  * Update or create a live stroke for a user

--- a/convex/paintingSessions.test.ts
+++ b/convex/paintingSessions.test.ts
@@ -1,0 +1,106 @@
+import { convexTest } from 'convex-test'
+import { describe, expect, test } from 'vitest'
+import { api } from './_generated/api'
+import type { Id } from './_generated/dataModel'
+import schema from './schema'
+import { modules } from './test.setup'
+
+function createTestBackend() {
+  return convexTest(schema, modules)
+}
+
+async function seedSession(options: {
+  ownerAuthId?: string
+  guestOwnerKey?: string
+  isPublic?: boolean
+}) {
+  const t = createTestBackend()
+  let ownerId: Id<'users'> | undefined
+
+  const sessionId = await t.run(async (ctx) => {
+    if (options.ownerAuthId) {
+      ownerId = await ctx.db.insert('users', {
+        authId: options.ownerAuthId,
+        email: `${options.ownerAuthId}@example.com`,
+      })
+    }
+
+    return await ctx.db.insert('paintingSessions', {
+      createdBy: ownerId,
+      guestOwnerKey: options.guestOwnerKey,
+      isPublic: options.isPublic ?? false,
+      canvasWidth: 800,
+      canvasHeight: 600,
+      strokeCounter: 0,
+    })
+  })
+
+  return { t, sessionId }
+}
+
+describe('painting session thumbnails', () => {
+  test('allows the signed-in owner to update a private session thumbnail', async () => {
+    const ownerAuthId = 'thumbnail-owner'
+    const { t, sessionId } = await seedSession({ ownerAuthId })
+
+    await t.withIdentity({ subject: ownerAuthId }).mutation(
+      api.paintingSessions.updateSessionThumbnail,
+      { sessionId, thumbnailUrl: 'data:image/jpeg;base64,owner' },
+    )
+
+    const session = await t.run(async (ctx) => await ctx.db.get(sessionId))
+    expect(session?.thumbnailUrl).toBe('data:image/jpeg;base64,owner')
+  })
+
+  test('rejects anonymous and non-owner writes to a private session thumbnail', async () => {
+    const { t, sessionId } = await seedSession({ ownerAuthId: 'thumbnail-owner' })
+    const args = { sessionId, thumbnailUrl: 'data:image/jpeg;base64,attacker' }
+
+    await expect(
+      t.mutation(api.paintingSessions.updateSessionThumbnail, args),
+    ).rejects.toThrow('Unauthorized')
+
+    await expect(
+      t.withIdentity({ subject: 'thumbnail-outsider' }).mutation(
+        api.paintingSessions.updateSessionThumbnail,
+        args,
+      ),
+    ).rejects.toThrow('Unauthorized')
+
+    const session = await t.run(async (ctx) => await ctx.db.get(sessionId))
+    expect(session?.thumbnailUrl).toBeUndefined()
+  })
+
+  test('requires the matching key for a guest-owned private session', async () => {
+    const guestOwnerKey = 'guest-thumbnail-key'
+    const { t, sessionId } = await seedSession({ guestOwnerKey })
+    const args = { sessionId, thumbnailUrl: 'data:image/jpeg;base64,guest' }
+
+    await expect(
+      t.mutation(api.paintingSessions.updateSessionThumbnail, {
+        ...args,
+        guestKey: 'wrong-key',
+      }),
+    ).rejects.toThrow('Unauthorized')
+
+    await t.mutation(api.paintingSessions.updateSessionThumbnail, {
+      ...args,
+      guestKey: guestOwnerKey,
+    })
+
+    const session = await t.run(async (ctx) => await ctx.db.get(sessionId))
+    expect(session?.thumbnailUrl).toBe('data:image/jpeg;base64,guest')
+  })
+
+  test('allows thumbnail updates for publicly editable sessions', async () => {
+    const { t, sessionId } = await seedSession({ isPublic: true })
+
+    await t.mutation(api.paintingSessions.updateSessionThumbnail, {
+      sessionId,
+      thumbnailUrl: 'data:image/jpeg;base64,public',
+    })
+
+    const session = await t.run(async (ctx) => await ctx.db.get(sessionId))
+    expect(session?.thumbnailUrl).toBe('data:image/jpeg;base64,public')
+  })
+})

--- a/convex/paintingSessions.ts
+++ b/convex/paintingSessions.ts
@@ -2,6 +2,7 @@ import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { Doc, Id } from "./_generated/dataModel";
 import { createUserWithWelcomeTokens } from "./users";
+import { assertCanModifySession } from "./sessionAuth";
 
 /**
  * Create a new painting session
@@ -375,12 +376,15 @@ export const updateSessionThumbnail = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
     thumbnailUrl: v.string(),
+    guestKey: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const session = await ctx.db.get(args.sessionId);
     if (!session) {
       throw new Error("Session not found");
     }
+
+    await assertCanModifySession(ctx, session, args.guestKey);
 
     await ctx.db.patch(args.sessionId, {
       thumbnailUrl: args.thumbnailUrl,

--- a/convex/sessionAuth.ts
+++ b/convex/sessionAuth.ts
@@ -1,0 +1,28 @@
+import type { Doc } from "./_generated/dataModel";
+import type { QueryCtx } from "./_generated/server";
+
+/**
+ * Authorization for session-modifying mutations.
+ * Allows public sessions (unless ownerOnly), the signed-in owner, or the guest
+ * owner with a matching key.
+ */
+export async function assertCanModifySession(
+  ctx: QueryCtx,
+  session: Doc<"paintingSessions">,
+  guestKey: string | undefined,
+  opts?: { ownerOnly?: boolean },
+): Promise<void> {
+  if (session.isPublic && !opts?.ownerOnly) return;
+
+  const identity = await ctx.auth.getUserIdentity();
+  if (identity) {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
+      .first();
+    if (user && session.createdBy === user._id) return;
+  }
+
+  if (session.guestOwnerKey && guestKey && session.guestOwnerKey === guestKey) return;
+  throw new Error("Unauthorized");
+}

--- a/convex/strokes.ts
+++ b/convex/strokes.ts
@@ -1,30 +1,6 @@
-import { mutation, query, QueryCtx } from "./_generated/server";
-import { Doc } from "./_generated/dataModel";
+import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-
-/**
- * Authorization for session-modifying mutations.
- * Allows: public sessions (unless ownerOnly), the signed-in owner, or the
- * guest owner (matching guestOwnerKey). Throws "Unauthorized" otherwise.
- */
-export async function assertCanModifySession(
-  ctx: QueryCtx,
-  session: Doc<"paintingSessions">,
-  guestKey: string | undefined,
-  opts?: { ownerOnly?: boolean },
-): Promise<void> {
-  if (session.isPublic && !opts?.ownerOnly) return;
-  const identity = await ctx.auth.getUserIdentity();
-  if (identity) {
-    const user = await ctx.db
-      .query("users")
-      .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
-      .first();
-    if (user && session.createdBy === user._id) return;
-  }
-  if (session.guestOwnerKey && guestKey && session.guestOwnerKey === guestKey) return;
-  throw new Error("Unauthorized");
-}
+import { assertCanModifySession } from "./sessionAuth";
 
 /**
  * Add a new stroke to a painting session

--- a/src/hooks/useThumbnailGenerator.ts
+++ b/src/hooks/useThumbnailGenerator.ts
@@ -3,6 +3,7 @@ import { useMutation } from 'convex/react'
 import { api } from '../../convex/_generated/api'
 import { Id } from '../../convex/_generated/dataModel'
 import type { CanvasRef } from '../components/KonvaCanvas'
+import { getGuestKey } from '../utils/guestKey'
 
 interface UseThumbnailGeneratorOptions {
   sessionId?: Id<"paintingSessions">
@@ -109,7 +110,8 @@ export function useThumbnailGenerator({
               // Update the thumbnail in the database
               await updateThumbnail({
                 sessionId,
-                thumbnailUrl: thumbnailData
+                thumbnailUrl: thumbnailData,
+                guestKey: getGuestKey(sessionId) || undefined
               })
               console.log('[ThumbnailGenerator] Thumbnail updated successfully')
             }
@@ -169,7 +171,8 @@ export function useThumbnailGenerator({
           
           await updateThumbnail({
             sessionId,
-            thumbnailUrl: thumbnailData
+            thumbnailUrl: thumbnailData,
+            guestKey: getGuestKey(sessionId) || undefined
           })
         }
       }


### PR DESCRIPTION
## Summary

- protect thumbnail writes with the shared session modification policy
- pass guest ownership credentials from the thumbnail generator
- move session authorization into a dedicated backend helper
- add regression coverage for owner, outsider, guest-key, and public-session access

## Why

`updateSessionThumbnail` previously accepted any painting session ID without checking identity, visibility, or guest ownership. A caller who learned a private session ID could overwrite its Library preview and `lastModified` value.

This change applies the same authorization policy used by drawing mutations: private sessions require the signed-in owner or matching guest key, while publicly editable sessions preserve their existing collaboration behavior.

## Impact

Private Library previews can no longer be modified by anonymous users or authenticated non-owners. Guest-owned paintings continue to generate previews because the client now includes the stored guest key.

## Validation

- app TypeScript check
- Convex TypeScript check
- full Vitest suite: 25 tests passed
- focused ESLint: no errors (four pre-existing `no-explicit-any` warnings in `convex/strokes.ts`)
- `git diff --check`
