### PR TITLE
library: show only owned sessions

### DIFF
--- a/convex/paintingSessions.test.ts
+++ b/convex/paintingSessions.test.ts
@@ -104,3 +104,150 @@ describe('painting session thumbnails', () => {
     expect(session?.thumbnailUrl).toBe('data:image/jpeg;base64,public')
   })
 })
+
+describe('getUserSessions', () => {
+  test('returns only owned sessions and excludes every contribution source', async () => {
+    const t = createTestBackend()
+    const authId = 'library-owner'
+
+    await t.run(async (ctx) => {
+      const userId = await ctx.db.insert('users', {
+        authId,
+        email: `${authId}@example.com`,
+      })
+      const otherUserId = await ctx.db.insert('users', {
+        authId: 'other-owner',
+        email: 'other-owner@example.com',
+      })
+
+      await ctx.db.insert('paintingSessions', {
+        name: 'Owned canvas',
+        createdBy: userId,
+        isPublic: false,
+        canvasWidth: 800,
+        canvasHeight: 600,
+        strokeCounter: 0,
+        lastModified: 100,
+      })
+      const publicStrokeSessionId = await ctx.db.insert('paintingSessions', {
+        name: 'Contributed public stroke canvas',
+        createdBy: otherUserId,
+        isPublic: true,
+        canvasWidth: 800,
+        canvasHeight: 600,
+        strokeCounter: 1,
+      })
+      const privateUploadSessionId = await ctx.db.insert('paintingSessions', {
+        name: 'Contributed private upload canvas',
+        createdBy: otherUserId,
+        isPublic: false,
+        canvasWidth: 800,
+        canvasHeight: 600,
+        strokeCounter: 0,
+      })
+      const publicLayerSessionId = await ctx.db.insert('paintingSessions', {
+        name: 'Contributed public layer canvas',
+        createdBy: otherUserId,
+        isPublic: true,
+        canvasWidth: 800,
+        canvasHeight: 600,
+        strokeCounter: 0,
+      })
+
+      await ctx.db.insert('strokes', {
+        sessionId: publicStrokeSessionId,
+        userId,
+        userColor: '#000000',
+        points: [{ x: 0, y: 0 }],
+        brushColor: '#000000',
+        brushSize: 5,
+        opacity: 1,
+        strokeOrder: 1,
+      })
+
+      const storageId = await ctx.storage.store(new Blob(['image']))
+      await ctx.db.insert('uploadedImages', {
+        sessionId: privateUploadSessionId,
+        userId,
+        storageId,
+        filename: 'contribution.png',
+        mimeType: 'image/png',
+        width: 100,
+        height: 100,
+        x: 0,
+        y: 0,
+        scale: 1,
+        rotation: 0,
+        opacity: 1,
+        layerOrder: 0,
+      })
+
+      await ctx.db.insert('paintLayers', {
+        sessionId: publicLayerSessionId,
+        name: 'Contributed layer',
+        layerOrder: 0,
+        visible: true,
+        opacity: 1,
+        createdBy: userId,
+        createdAt: Date.now(),
+      })
+    })
+
+    const sessions = await t.withIdentity({ subject: authId }).query(
+      api.paintingSessions.getUserSessions,
+      {},
+    )
+
+    expect(sessions.map((session) => session.name)).toEqual(['Owned canvas'])
+  })
+
+  test('sorts owned sessions by lastModified descending', async () => {
+    const t = createTestBackend()
+    const authId = 'sorted-library-owner'
+
+    await t.run(async (ctx) => {
+      const userId = await ctx.db.insert('users', {
+        authId,
+        email: `${authId}@example.com`,
+      })
+
+      for (const [name, lastModified] of [
+        ['Old canvas', 100],
+        ['Newest canvas', 300],
+        ['Middle canvas', 200],
+      ] as const) {
+        await ctx.db.insert('paintingSessions', {
+          name,
+          createdBy: userId,
+          isPublic: false,
+          canvasWidth: 800,
+          canvasHeight: 600,
+          strokeCounter: 0,
+          lastModified,
+        })
+      }
+
+      await ctx.db.insert('paintingSessions', {
+        name: 'Deleted canvas',
+        createdBy: userId,
+        isPublic: false,
+        canvasWidth: 800,
+        canvasHeight: 600,
+        strokeCounter: 0,
+        lastModified: 400,
+        deletedAt: Date.now(),
+      })
+    })
+
+    const sessions = await t.withIdentity({ subject: authId }).query(
+      api.paintingSessions.getUserSessions,
+      {},
+    )
+
+    expect(sessions.map((session) => session.name)).toEqual([
+      'Newest canvas',
+      'Middle canvas',
+      'Old canvas',
+    ])
+  })
+})

--- a/convex/paintingSessions.ts
+++ b/convex/paintingSessions.ts
@@ -208,49 +208,18 @@ export const getUserSessions = query({
       return [];
     }
 
-    // Collect sessionIds associated with this user through ownership or contributions
-    const sessionIdSet = new Set<Id<"paintingSessions">>();
-
-    // 1) Owned sessions (indexed — avoids scanning every session doc,
-    // which blows the 16MB read limit because thumbnails are stored inline)
+    // Owned sessions only. Contributions to another user's canvas do not
+    // grant ownership and must not expose that canvas in My Library.
+    // The index avoids scanning every session doc, which is especially
+    // important while thumbnails are stored inline.
     const ownedSessions = await ctx.db
       .query("paintingSessions")
       .withIndex("by_creator", (q) => q.eq("createdBy", user._id))
       .order("desc")
       .collect();
-    ownedSessions.forEach((s) => sessionIdSet.add(s._id));
-
-    // 2-4) Sessions contributed to. Stroke docs carry full point arrays, so
-    // reads must stay bounded: only the most recent contributions are
-    // considered. Older contributed-to sessions won't appear unless owned.
-    const userStrokes = await ctx.db
-      .query("strokes")
-      .withIndex("by_user", (q) => q.eq("userId", user._id))
-      .order("desc")
-      .take(300);
-    userStrokes.forEach((st) => sessionIdSet.add(st.sessionId));
-
-    const userUploads = await ctx.db
-      .query("uploadedImages")
-      .withIndex("by_user", (q) => q.eq("userId", user._id))
-      .order("desc")
-      .take(200);
-    userUploads.forEach((img) => sessionIdSet.add(img.sessionId));
-
-    const userLayers = await ctx.db
-      .query("paintLayers")
-      .withIndex("by_user", (q) => q.eq("createdBy", user._id))
-      .order("desc")
-      .take(200);
-    userLayers.forEach((pl) => sessionIdSet.add(pl.sessionId));
-
-    // Fetch session docs for all collected IDs
-    const sessions: Array<Doc<"paintingSessions">> = [];
-
-    for (const sessionId of sessionIdSet) {
-      const session = await ctx.db.get(sessionId);
-      if (session && session.deletedAt === undefined) sessions.push(session);
-    }
+    const sessions = ownedSessions.filter(
+      (session) => session.deletedAt === undefined,
+    );
 
     // Sort by lastModified (fallback to creation time), desc
     sessions.sort((a, b) => {


### PR DESCRIPTION
## Summary

- restrict My Library to sessions owned by the authenticated user
- remove contribution-derived discovery through strokes, uploads, and paint layers
- continue excluding soft-deleted sessions and preserve last-modified ordering
- add regression coverage for public/private contributions, ordering, and deleted sessions

## Why

The Library backend mixed ownership with contribution history. A user who had contributed to another canvas could receive that session in My Library even after it became private, exposing its name and thumbnail while presenting rename/delete controls that the backend correctly rejected.

## Impact

My Library now matches its ownership semantics and only returns canvases the signed-in user can manage. Shared-session discovery can be added later as a separate capability-aware feature.

## Validation

- app TypeScript check
- Convex TypeScript check
- full Vitest suite: 27 tests passed
- focused ESLint: no errors
- independent review: no blocking findings
- `git diff --check`
