### PR TITLE
security: authorize image mutations

### DIFF
--- a/convex/images.test.ts
+++ b/convex/images.test.ts
@@ -1,0 +1,265 @@
+import { convexTest } from 'convex-test'
+import { describe, expect, test } from 'vitest'
+import { api } from './_generated/api'
+import type { Id } from './_generated/dataModel'
+import schema from './schema'
+import { modules } from './test.setup'
+
+function createTestBackend() {
+  return convexTest(schema, modules)
+}
+
+async function seedImages(options: {
+  ownerAuthId?: string
+  guestOwnerKey?: string
+  isPublic?: boolean
+} = {}) {
+  const t = createTestBackend()
+  let ownerId: Id<'users'> | undefined
+
+  const seeded = await t.run(async (ctx) => {
+    if (options.ownerAuthId) {
+      ownerId = await ctx.db.insert('users', {
+        authId: options.ownerAuthId,
+        email: `${options.ownerAuthId}@example.com`,
+      })
+    }
+
+    const sessionId = await ctx.db.insert('paintingSessions', {
+      createdBy: ownerId,
+      guestOwnerKey: options.guestOwnerKey,
+      isPublic: options.isPublic ?? false,
+      canvasWidth: 800,
+      canvasHeight: 600,
+      strokeCounter: 1,
+      paintLayerOrder: 0,
+    })
+    const storageId = await ctx.storage.store(
+      new Blob(['original image'], { type: 'image/png' }),
+    )
+    const uploadedImageId = await ctx.db.insert('uploadedImages', {
+      sessionId,
+      storageId,
+      filename: 'original.png',
+      mimeType: 'image/png',
+      width: 100,
+      height: 100,
+      x: 50,
+      y: 50,
+      scale: 1,
+      rotation: 0,
+      opacity: 1,
+      layerOrder: 1,
+    })
+    const aiImageId = await ctx.db.insert('aiGeneratedImages', {
+      sessionId,
+      imageUrl: 'https://example.com/ai.png',
+      width: 100,
+      height: 100,
+      x: 50,
+      y: 50,
+      scale: 1,
+      rotation: 0,
+      opacity: 1,
+      layerOrder: 2,
+      createdAt: Date.now(),
+    })
+    const strokeId = await ctx.db.insert('strokes', {
+      sessionId,
+      layerId: uploadedImageId,
+      userColor: '#000000',
+      points: [{ x: 1, y: 1 }],
+      brushColor: '#000000',
+      brushSize: 2,
+      opacity: 1,
+      strokeOrder: 1,
+    })
+
+    return { sessionId, storageId, uploadedImageId, aiImageId, strokeId }
+  })
+
+  return { t, ownerId, ...seeded }
+}
+
+function uploadArgs(
+  sessionId: Id<'paintingSessions'>,
+  storageId: Id<'_storage'>,
+) {
+  return {
+    sessionId,
+    storageId,
+    filename: 'new.png',
+    mimeType: 'image/png',
+    width: 200,
+    height: 100,
+    x: 400,
+    y: 300,
+  }
+}
+
+describe('image mutation authorization', () => {
+  test('allows the signed-in owner and derives uploaded image attribution server-side', async () => {
+    const ownerAuthId = 'image-owner'
+    const { t, ownerId, sessionId, storageId } = await seedImages({ ownerAuthId })
+    const owner = t.withIdentity({ subject: ownerAuthId })
+
+    await expect(
+      owner.mutation(api.images.generateUploadUrl, { sessionId }),
+    ).resolves.toContain('/api/storage/upload')
+
+    const uploadedImageId = await owner.mutation(
+      api.images.uploadImage,
+      uploadArgs(sessionId, storageId),
+    )
+    await owner.mutation(api.images.addAIGeneratedImage, {
+      sessionId,
+      imageUrl: 'https://example.com/new-ai.png',
+      width: 200,
+      height: 100,
+    })
+
+    const uploadedImage = await t.run(async (ctx) => ctx.db.get(uploadedImageId))
+    expect(uploadedImage?.userId).toBe(ownerId)
+  })
+
+  test('denies private direct-session mutations before creating records or upload URLs', async () => {
+    const { t, sessionId, storageId } = await seedImages({ ownerAuthId: 'owner' })
+    const outsider = t.withIdentity({ subject: 'outsider' })
+
+    await expect(
+      t.mutation(api.images.generateUploadUrl, { sessionId }),
+    ).rejects.toThrow('Unauthorized')
+    await expect(
+      outsider.mutation(api.images.uploadImage, uploadArgs(sessionId, storageId)),
+    ).rejects.toThrow('Unauthorized')
+    await expect(
+      outsider.mutation(api.images.addAIGeneratedImage, {
+        sessionId,
+        imageUrl: 'https://example.com/unauthorized.png',
+        width: 100,
+        height: 100,
+      }),
+    ).rejects.toThrow('Unauthorized')
+
+    const counts = await t.run(async (ctx) => ({
+      uploaded: (await ctx.db.query('uploadedImages').collect()).length,
+      ai: (await ctx.db.query('aiGeneratedImages').collect()).length,
+    }))
+    expect(counts).toEqual({ uploaded: 1, ai: 1 })
+  })
+
+  test('denies all record-based mutations without destructive side effects', async () => {
+    const { t, uploadedImageId, aiImageId, storageId, strokeId } =
+      await seedImages({ ownerAuthId: 'owner' })
+    const outsider = t.withIdentity({ subject: 'outsider' })
+
+    const attempts = [
+      () => outsider.mutation(api.images.updateImageTransform, {
+        imageId: uploadedImageId,
+        x: 999,
+      }),
+      () => outsider.mutation(api.images.updateAIImageTransform, {
+        imageId: aiImageId,
+        opacity: 0,
+      }),
+      () => outsider.mutation(api.images.updateImageLayerOrder, {
+        imageId: uploadedImageId,
+        newLayerOrder: 9,
+      }),
+      () => outsider.mutation(api.images.updateAIImageLayerOrder, {
+        imageId: aiImageId,
+        newLayerOrder: 9,
+      }),
+      () => outsider.mutation(api.images.deleteImage, { imageId: uploadedImageId }),
+      () => outsider.mutation(api.images.deleteAIImage, { imageId: aiImageId }),
+    ]
+    for (const attempt of attempts) {
+      await expect(attempt()).rejects.toThrow('Unauthorized')
+    }
+
+    const state = await t.run(async (ctx) => ({
+      uploaded: await ctx.db.get(uploadedImageId),
+      ai: await ctx.db.get(aiImageId),
+      stroke: await ctx.db.get(strokeId),
+      storedText: await (await ctx.storage.get(storageId))?.text(),
+    }))
+    expect(state.uploaded).toMatchObject({ x: 50, layerOrder: 1 })
+    expect(state.ai).toMatchObject({ opacity: 1, layerOrder: 2 })
+    expect(state.stroke).not.toBeNull()
+    expect(state.storedText).toBe('original image')
+  })
+
+  test('requires the matching guest key and permits every image mutation with it', async () => {
+    const guestKey = 'guest-image-key'
+    const { t, sessionId, uploadedImageId, aiImageId } =
+      await seedImages({ guestOwnerKey: guestKey })
+    const newStorageId = await t.run(async (ctx) =>
+      ctx.storage.store(new Blob(['guest image'], { type: 'image/png' })),
+    )
+
+    await expect(
+      t.mutation(api.images.updateImageTransform, {
+        imageId: uploadedImageId,
+        x: 75,
+        guestKey: 'wrong-key',
+      }),
+    ).rejects.toThrow('Unauthorized')
+    await expect(
+      t.mutation(api.images.generateUploadUrl, { sessionId, guestKey }),
+    ).resolves.toContain('/api/storage/upload')
+    await t.mutation(api.images.uploadImage, {
+      ...uploadArgs(sessionId, newStorageId),
+      guestKey,
+    })
+    await t.mutation(api.images.addAIGeneratedImage, {
+      sessionId,
+      imageUrl: 'https://example.com/guest-ai.png',
+      width: 100,
+      height: 100,
+      guestKey,
+    })
+    await t.mutation(api.images.updateImageTransform, {
+      imageId: uploadedImageId,
+      x: 75,
+      guestKey,
+    })
+    await t.mutation(api.images.updateAIImageTransform, {
+      imageId: aiImageId,
+      opacity: 0.5,
+      guestKey,
+    })
+    await t.mutation(api.images.updateImageLayerOrder, {
+      imageId: uploadedImageId,
+      newLayerOrder: 2,
+      guestKey,
+    })
+    await t.mutation(api.images.updateAIImageLayerOrder, {
+      imageId: aiImageId,
+      newLayerOrder: 0,
+      guestKey,
+    })
+    await t.mutation(api.images.deleteImage, { imageId: uploadedImageId, guestKey })
+    await t.mutation(api.images.deleteAIImage, { imageId: aiImageId, guestKey })
+
+    const deleted = await t.run(async (ctx) => ({
+      uploaded: await ctx.db.get(uploadedImageId),
+      ai: await ctx.db.get(aiImageId),
+    }))
+    expect(deleted).toEqual({ uploaded: null, ai: null })
+  })
+
+  test('preserves anonymous collaboration for public sessions', async () => {
+    const { t, sessionId, uploadedImageId } = await seedImages({ isPublic: true })
+
+    await expect(
+      t.mutation(api.images.generateUploadUrl, { sessionId }),
+    ).resolves.toContain('/api/storage/upload')
+    await t.mutation(api.images.updateImageTransform, {
+      imageId: uploadedImageId,
+      rotation: 45,
+    })
+
+    const image = await t.run(async (ctx) => ctx.db.get(uploadedImageId))
+    expect(image?.rotation).toBe(45)
+  })
+})

--- a/convex/images.ts
+++ b/convex/images.ts
@@ -1,12 +1,12 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { Id } from "./_generated/dataModel";
+import { assertCanModifySession } from "./sessionAuth";
 
 // Upload an image to storage and create a record
 export const uploadImage = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
-    userId: v.optional(v.id("users")),
     storageId: v.id("_storage"),
     filename: v.string(),
     mimeType: v.string(),
@@ -16,8 +16,23 @@ export const uploadImage = mutation({
     y: v.number(),
     canvasWidth: v.optional(v.number()),
     canvasHeight: v.optional(v.number()),
+    guestKey: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    const uploadSession = await ctx.db.get(args.sessionId);
+    if (!uploadSession) throw new Error("Session not found");
+    await assertCanModifySession(ctx, uploadSession, args.guestKey);
+
+    let userId: Id<"users"> | undefined;
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity) {
+      const user = await ctx.db
+        .query("users")
+        .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
+        .first();
+      userId = user?._id;
+    }
+
     // Get the current max layer order from ALL images (uploaded and AI)
     const uploadedImages = await ctx.db
       .query("uploadedImages")
@@ -30,7 +45,6 @@ export const uploadImage = mutation({
       .collect();
     
     // Get painting session to check paint layer order
-    const uploadSession = await ctx.db.get(args.sessionId);
     const paintLayerOrder = uploadSession?.paintLayerOrder ?? 0;
     // Compute scale to fit original image within canvas without altering the stored pixels
     const canvasWidth = args.canvasWidth ?? uploadSession?.canvasWidth ?? args.width;
@@ -57,7 +71,7 @@ export const uploadImage = mutation({
     // Create the image record
     const imageId = await ctx.db.insert("uploadedImages", {
       sessionId: args.sessionId,
-      userId: args.userId,
+      userId,
       storageId: args.storageId,
       filename: args.filename,
       mimeType: args.mimeType,
@@ -86,8 +100,13 @@ export const addAIGeneratedImage = mutation({
     height: v.number(),
     canvasWidth: v.optional(v.number()),
     canvasHeight: v.optional(v.number()),
+    guestKey: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    const session = await ctx.db.get(args.sessionId);
+    if (!session) throw new Error("Session not found");
+    await assertCanModifySession(ctx, session, args.guestKey);
+
     // Get the current max layer order from ALL images (uploaded and AI)
     const uploadedImages = await ctx.db
       .query("uploadedImages")
@@ -103,7 +122,6 @@ export const addAIGeneratedImage = mutation({
     let canvasWidth = args.canvasWidth || 800;
     let canvasHeight = args.canvasHeight || 600;
     
-    const session = await ctx.db.get(args.sessionId);
     const paintLayerOrder = session?.paintLayerOrder ?? 0;
     
     // Find max layer order across all images
@@ -245,9 +263,15 @@ export const updateImageTransform = mutation({
     scaleY: v.optional(v.number()),
     rotation: v.optional(v.number()),
     opacity: v.optional(v.number()),
+    guestKey: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const { imageId, ...updates } = args;
+    const { imageId, guestKey, ...updates } = args;
+    const image = await ctx.db.get(imageId);
+    if (!image) throw new Error("Image not found");
+    const session = await ctx.db.get(image.sessionId);
+    if (!session) throw new Error("Session not found");
+    await assertCanModifySession(ctx, session, guestKey);
     
     // Only update provided fields
     const updateFields: any = {};
@@ -280,9 +304,15 @@ export const updateAIImageTransform = mutation({
     scaleY: v.optional(v.number()),
     rotation: v.optional(v.number()),
     opacity: v.optional(v.number()),
+    guestKey: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const { imageId, ...updates } = args;
+    const { imageId, guestKey, ...updates } = args;
+    const image = await ctx.db.get(imageId);
+    if (!image) throw new Error("AI image not found");
+    const session = await ctx.db.get(image.sessionId);
+    if (!session) throw new Error("Session not found");
+    await assertCanModifySession(ctx, session, guestKey);
     
     // Only update provided fields
     const updateFields: any = {};
@@ -307,10 +337,14 @@ export const updateImageLayerOrder = mutation({
   args: {
     imageId: v.id("uploadedImages"),
     newLayerOrder: v.number(),
+    guestKey: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const image = await ctx.db.get(args.imageId);
     if (!image) throw new Error("Image not found");
+    const session = await ctx.db.get(image.sessionId);
+    if (!session) throw new Error("Session not found");
+    await assertCanModifySession(ctx, session, args.guestKey);
 
     // Get all images (uploaded and AI) for the session to maintain unique ordering
     const uploadedImages = await ctx.db
@@ -371,10 +405,16 @@ export const updateImageLayerOrder = mutation({
 
 // Delete an image
 export const deleteImage = mutation({
-  args: { imageId: v.id("uploadedImages") },
+  args: {
+    imageId: v.id("uploadedImages"),
+    guestKey: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     const image = await ctx.db.get(args.imageId);
     if (!image) throw new Error("Image not found");
+    const session = await ctx.db.get(image.sessionId);
+    if (!session) throw new Error("Session not found");
+    await assertCanModifySession(ctx, session, args.guestKey);
 
     // Delete any strokes attached to this image layer
     const attachedStrokes = await ctx.db
@@ -416,7 +456,6 @@ export const deleteImage = mutation({
       .collect();
     
     // Get paint layer order
-    const session = await ctx.db.get(image.sessionId);
     const paintLayerOrder = session?.paintLayerOrder ?? 0;
     
     // Combine all layers and filter out the deleted one
@@ -446,8 +485,17 @@ export const deleteImage = mutation({
 });
 
 // Generate upload URL for client-side upload
-export const generateUploadUrl = mutation(async (ctx) => {
-  return await ctx.storage.generateUploadUrl();
+export const generateUploadUrl = mutation({
+  args: {
+    sessionId: v.id("paintingSessions"),
+    guestKey: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const session = await ctx.db.get(args.sessionId);
+    if (!session) throw new Error("Session not found");
+    await assertCanModifySession(ctx, session, args.guestKey);
+    return await ctx.storage.generateUploadUrl();
+  },
 });
 
 // Get AI-generated images for a session
@@ -484,10 +532,14 @@ export const updateAIImageLayerOrder = mutation({
   args: {
     imageId: v.id("aiGeneratedImages"),
     newLayerOrder: v.number(),
+    guestKey: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const image = await ctx.db.get(args.imageId);
     if (!image) throw new Error("AI image not found");
+    const session = await ctx.db.get(image.sessionId);
+    if (!session) throw new Error("Session not found");
+    await assertCanModifySession(ctx, session, args.guestKey);
 
     // Get all images (uploaded and AI) for the session to maintain unique ordering
     const uploadedImages = await ctx.db
@@ -548,7 +600,10 @@ export const updateAIImageLayerOrder = mutation({
 
 // Delete an AI-generated image
 export const deleteAIImage = mutation({
-  args: { imageId: v.id("aiGeneratedImages") },
+  args: {
+    imageId: v.id("aiGeneratedImages"),
+    guestKey: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     console.log('[deleteAIImage] Attempting to delete AI image:', args.imageId);
     
@@ -557,6 +612,10 @@ export const deleteAIImage = mutation({
       console.error('[deleteAIImage] AI image not found:', args.imageId);
       throw new Error("AI image not found");
     }
+
+    const session = await ctx.db.get(image.sessionId);
+    if (!session) throw new Error("Session not found");
+    await assertCanModifySession(ctx, session, args.guestKey);
     
     console.log('[deleteAIImage] Found image to delete:', image);
 
@@ -598,7 +657,6 @@ export const deleteAIImage = mutation({
       .collect();
     
     // Get paint layer order
-    const session = await ctx.db.get(image.sessionId);
     const paintLayerOrder = session?.paintLayerOrder ?? 0;
     
     // Combine all layers and filter out the deleted one

--- a/src/components/ImageUploadModal.tsx
+++ b/src/components/ImageUploadModal.tsx
@@ -3,11 +3,11 @@ import { Upload, X } from 'lucide-react'
 import { useMutation } from 'convex/react'
 import { api } from '../../convex/_generated/api'
 import { Id } from '../../convex/_generated/dataModel'
-import { uploadImageFile, validateImageFile, ACCEPTED_TYPES, MAX_FILE_SIZE } from '../utils/imageUpload'
+import { uploadImageFile, validateImageFile, ACCEPTED_TYPES } from '../utils/imageUpload'
+import { getGuestKey } from '../utils/guestKey'
 
 interface ImageUploadModalProps {
   sessionId: Id<"paintingSessions"> | null
-  userId?: Id<"users"> | null
   onImageUploaded?: (imageId: Id<"uploadedImages">) => void
   onClose: () => void
   canvasWidth?: number
@@ -18,7 +18,6 @@ interface ImageUploadModalProps {
 
 export function ImageUploadModal({ 
   sessionId, 
-  userId, 
   onImageUploaded, 
   onClose,
   canvasWidth = 800,
@@ -93,7 +92,7 @@ export function ImageUploadModal({
         selectedFile,
         {
           sessionId,
-          userId,
+          guestKey: getGuestKey(sessionId) || undefined,
           canvasWidth,
           canvasHeight,
           onImageUploaded,

--- a/src/components/KonvaCanvas.tsx
+++ b/src/components/KonvaCanvas.tsx
@@ -12,6 +12,7 @@ import { api } from '../../convex/_generated/api'
 import { shouldShowAdminFeatures } from '../utils/environment'
 import { uploadImageFile, validateImageFile, ACCEPTED_TYPES } from '../utils/imageUpload'
 import { useClipboardContext } from '../context/ClipboardContext'
+import { getGuestKey } from '../utils/guestKey'
 
 const average = (a: number, b: number): number => (a + b) / 2
 
@@ -230,6 +231,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
     endTaper = 0,
     endCap = true,
   } = props
+  const guestKey = getGuestKey(sessionId) || undefined
   
   const stageRef = useRef<Konva.Stage>(null)
   const strokeLayerRef = useRef<Konva.Layer>(null)
@@ -294,7 +296,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
   const { images } = useSessionImages(sessionId)
   
   // Get AI generated images separately
-  const aiImages = useQuery(api.images.getAIGeneratedImages, sessionId ? { sessionId, guestKey: (typeof window !== 'undefined' ? (JSON.parse(localStorage.getItem('wepaint_guest_keys_v1') || '{}') || {})[sessionId as any] : undefined) } : 'skip')
+  const aiImages = useQuery(api.images.getAIGeneratedImages, sessionId ? { sessionId, guestKey } : 'skip')
   // Get paint layers for transforms
   const paintLayersData = useQuery(api.paintLayers.getPaintLayers, sessionId ? { sessionId, guestKey: (typeof window !== 'undefined' ? (JSON.parse(localStorage.getItem('wepaint_guest_keys_v1') || '{}') || {})[sessionId as any] : undefined) } : 'skip')
   
@@ -411,12 +413,13 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
             scaleX: desiredScale,
             scaleY: desiredScale,
             x: desiredX,
-            y: desiredY
+            y: desiredY,
+            guestKey,
           } as any)
           autoFittedRef.current.add(img._id)
         }
       })
-  }, [images, dimensions.width, dimensions.height, updateImageTransform])
+  }, [images, dimensions.width, dimensions.height, updateImageTransform, guestKey])
 
   // Auto-fit newly loaded AI images once as well
   useEffect(() => {
@@ -435,12 +438,13 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
           scaleX: desiredScale,
           scaleY: desiredScale,
           x: desiredX,
-          y: desiredY
+          y: desiredY,
+          guestKey,
         } as any)
         autoFittedRef.current.add(img._id)
       }
     })
-  }, [aiImages, dimensions.width, dimensions.height, updateAIImageTransform])
+  }, [aiImages, dimensions.width, dimensions.height, updateAIImageTransform, guestKey])
 
   // Remove confirmed strokes from pending when they appear in the strokes array
   useEffect(() => {
@@ -997,7 +1001,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
         imageFile,
         {
           sessionId,
-          userId: currentUser.id,
+          guestKey,
           canvasWidth: dimensions.width || 800,
           canvasHeight: dimensions.height || 600,
           onImageUploaded,
@@ -1014,7 +1018,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
     } finally {
       setIsUploading(false)
     }
-  }, [sessionId, isUploading, currentUser.id, dimensions, onImageUploaded, generateUploadUrl, uploadImage])
+  }, [sessionId, isUploading, dimensions, onImageUploaded, generateUploadUrl, uploadImage, guestKey])
 
   // Clipboard paste handler: allow when over canvas or toolbox and when AI modal not open
   useEffect(() => {
@@ -1069,7 +1073,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
           fileWithName,
           {
             sessionId,
-            userId: currentUser.id,
+            guestKey,
             canvasWidth: dimensions.width || 800,
             canvasHeight: dimensions.height || 600,
             onImageUploaded,
@@ -1095,7 +1099,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
     isMouseOverCanvas,
     isMouseOverToolbox,
     isAIModalOpen,
-    currentUser.id,
+    guestKey,
     dimensions.width,
     dimensions.height,
     onImageUploaded,
@@ -1683,7 +1687,8 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
                         await updateImageTransform({
                           imageId: layer.id as Id<"uploadedImages">,
                           x: node.x(),
-                          y: node.y()
+                          y: node.y(),
+                          guestKey,
                         })
                       }}
                       onTransformEnd={async (e) => {
@@ -1698,6 +1703,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
                           rotation: newRotation,
                           x: node.x(),
                           y: node.y(),
+                          guestKey,
                         } as any)
                         // Do not reset node scale here; let controlled props re-render with persisted values
                       }}
@@ -1871,7 +1877,8 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
                         await updateAIImageTransform({
                           imageId: layer.id as Id<"aiGeneratedImages">,
                           x: node.x(),
-                          y: node.y()
+                          y: node.y(),
+                          guestKey,
                         })
                       }}
                       onTransformEnd={async (e) => {
@@ -1886,6 +1893,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
                           rotation: newRotation,
                           x: node.x(),
                           y: node.y(),
+                          guestKey,
                         } as any)
                         // Do not reset node scale here; let controlled props re-render with persisted values
                       }}

--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -251,6 +251,7 @@ export function PaintingView() {
   // a malformed URL id would otherwise throw validation errors in every query.
   const sessionReady = !!sessionId && sessionStatus === 'ok'
   const validSessionId = sessionReady ? sessionId : null
+  const imageGuestKey = getGuestKey(validSessionId) || undefined
   const sessionError: 'not_found' | 'unauthorized' | null =
     sessionId && (sessionStatus === 'not_found' || sessionStatus === 'unauthorized') ? sessionStatus : null
 
@@ -708,6 +709,7 @@ export function PaintingView() {
         // Add the AI-generated image to Convex
         const newImageId = await addAIGeneratedImage({
           sessionId,
+          guestKey: getGuestKey(sessionId) || undefined,
           imageUrl,
           width: img.naturalWidth || img.width,
           height: img.naturalHeight || img.height,
@@ -915,7 +917,7 @@ export function PaintingView() {
       const aiImage = aiImages?.find(img => img._id === layerId)
       if (aiImage) {
         console.log('[PaintingView] Toggling AI image visibility', { layerId, to: visible })
-        await updateAIImageTransformMutation({ imageId: layerId as Id<'aiGeneratedImages'>, opacity: visible ? 1 : 0 })
+        await updateAIImageTransformMutation({ imageId: layerId as Id<'aiGeneratedImages'>, opacity: visible ? 1 : 0, guestKey: imageGuestKey })
         console.log('[PaintingView] AI image opacity updated OK', { layerId, to: visible ? 1 : 0 })
         return
       }
@@ -924,7 +926,7 @@ export function PaintingView() {
     } catch (err) {
       console.error('[PaintingView] Error toggling layer visibility', { layerId, visible, err })
     }
-  }, [images, aiImages, paintLayers, updateImageTransform, updateAIImageTransformMutation, updatePaintLayer])
+  }, [images, aiImages, paintLayers, updateImageTransform, updateAIImageTransformMutation, updatePaintLayer, imageGuestKey])
 
   const handleLayerDelete = useCallback(async (layerId: string) => {
     // console.log('[PaintingView] handleLayerDelete called with layerId:', layerId)
@@ -972,7 +974,7 @@ export function PaintingView() {
     if (aiImage) {
       // console.log('[PaintingView] Deleting AI image:', layerId)
       try {
-        await deleteAIImageMutation({ imageId: layerId as Id<"aiGeneratedImages"> })
+        await deleteAIImageMutation({ imageId: layerId as Id<"aiGeneratedImages">, guestKey: imageGuestKey })
         // console.log('[PaintingView] AI image deleted successfully')
       } catch (error) {
         console.error('[PaintingView] Error deleting AI image:', error)
@@ -980,7 +982,7 @@ export function PaintingView() {
     } else {
       console.warn('[PaintingView] Layer not found for deletion:', layerId)
     }
-  }, [images, aiImages, paintLayers, clearSession, deleteImage, deletePaintLayer, deleteAIImageMutation])
+  }, [images, aiImages, paintLayers, clearSession, deleteImage, deletePaintLayer, deleteAIImageMutation, imageGuestKey])
 
   const handleLayerReorder = useCallback(async (layerId: string, newOrder: number) => {
     if (!sessionId) return
@@ -1022,10 +1024,11 @@ export function PaintingView() {
     if (aiImage) {
       await updateAIImageTransformMutation({
         imageId: layerId as Id<"aiGeneratedImages">,
-        opacity
+        opacity,
+        guestKey: imageGuestKey,
       })
     }
-  }, [images, aiImages, updateImageTransform, updateAIImageTransformMutation])
+  }, [images, aiImages, updateImageTransform, updateAIImageTransformMutation, imageGuestKey])
 
   // Handle creating new paint layer
   const handleCreatePaintLayer = useCallback(async () => {
@@ -1232,7 +1235,6 @@ export function PaintingView() {
       {showImageUpload && (
         <ImageUploadModal
           sessionId={sessionId}
-          userId={currentUser.id}
           onImageUploaded={handleImageUploaded}
           onClose={() => {
             setShowImageUpload(false)

--- a/src/hooks/useSessionImages.ts
+++ b/src/hooks/useSessionImages.ts
@@ -26,10 +26,12 @@ export interface SessionImage {
 }
 
 export function useSessionImages(sessionId: Id<"paintingSessions"> | null) {
+  const guestKey = getGuestKey(sessionId) || undefined;
+
   // Query images for the session
   const images = useQuery(
     api.images.getSessionImages,
-    sessionId ? { sessionId, guestKey: getGuestKey(sessionId) || undefined } : "skip"
+    sessionId ? { sessionId, guestKey } : "skip"
   );
 
   // Mutations
@@ -43,32 +45,32 @@ export function useSessionImages(sessionId: Id<"paintingSessions"> | null) {
     x: number,
     y: number
   ) => {
-    await updateTransform({ imageId, x, y });
-  }, [updateTransform]);
+    await updateTransform({ imageId, x, y, guestKey });
+  }, [updateTransform, guestKey]);
 
   // Update image scale
   const scaleImage = useCallback(async (
     imageId: Id<"uploadedImages">,
     scale: number
   ) => {
-    await updateTransform({ imageId, scale });
-  }, [updateTransform]);
+    await updateTransform({ imageId, scale, guestKey });
+  }, [updateTransform, guestKey]);
 
   // Update image rotation
   const rotateImage = useCallback(async (
     imageId: Id<"uploadedImages">,
     rotation: number
   ) => {
-    await updateTransform({ imageId, rotation });
-  }, [updateTransform]);
+    await updateTransform({ imageId, rotation, guestKey });
+  }, [updateTransform, guestKey]);
 
   // Update image opacity
   const setImageOpacity = useCallback(async (
     imageId: Id<"uploadedImages">,
     opacity: number
   ) => {
-    await updateTransform({ imageId, opacity });
-  }, [updateTransform]);
+    await updateTransform({ imageId, opacity, guestKey });
+  }, [updateTransform, guestKey]);
 
   // Update full transform
   const updateImageTransform = useCallback(async (
@@ -86,24 +88,24 @@ export function useSessionImages(sessionId: Id<"paintingSessions"> | null) {
     try {
       console.log('[useSessionImages] updateImageTransform called', { imageId, transform })
     } catch {}
-    await updateTransform({ imageId, ...transform });
+    await updateTransform({ imageId, ...transform, guestKey });
     try {
       console.log('[useSessionImages] updateImageTransform completed', { imageId, transform })
     } catch {}
-  }, [updateTransform]);
+  }, [updateTransform, guestKey]);
 
   // Change layer order
   const changeLayerOrder = useCallback(async (
     imageId: Id<"uploadedImages">,
     newLayerOrder: number
   ) => {
-    await updateLayerOrder({ imageId, newLayerOrder });
-  }, [updateLayerOrder]);
+    await updateLayerOrder({ imageId, newLayerOrder, guestKey });
+  }, [updateLayerOrder, guestKey]);
 
   // Delete image
   const deleteImage = useCallback(async (imageId: Id<"uploadedImages">) => {
-    await deleteImageMutation({ imageId });
-  }, [deleteImageMutation]);
+    await deleteImageMutation({ imageId, guestKey });
+  }, [deleteImageMutation, guestKey]);
 
   return {
     images: images || [],

--- a/src/utils/imageUpload.ts
+++ b/src/utils/imageUpload.ts
@@ -5,7 +5,7 @@ export const ACCEPTED_TYPES = ['image/png', 'image/jpeg', 'image/jpg', 'image/gi
 
 export interface ImageUploadOptions {
   sessionId: Id<"paintingSessions">
-  userId?: Id<"users"> | null
+  guestKey?: string
   canvasWidth?: number
   canvasHeight?: number
   onImageUploaded?: (imageId: Id<"uploadedImages">) => void
@@ -15,6 +15,20 @@ export interface ImageUploadResult {
   success: boolean
   error?: string
   imageId?: Id<"uploadedImages">
+}
+
+interface UploadImageMutationArgs {
+  sessionId: Id<"paintingSessions">
+  storageId: Id<"_storage">
+  filename: string
+  mimeType: string
+  width: number
+  height: number
+  x: number
+  y: number
+  canvasWidth?: number
+  canvasHeight?: number
+  guestKey?: string
 }
 
 export function validateImageFile(file: File): { valid: boolean; error?: string } {
@@ -110,10 +124,13 @@ export function resizeImageToFitCanvas(
 export async function uploadImageFile(
   file: File,
   options: ImageUploadOptions,
-  generateUploadUrl: () => Promise<string>,
-  uploadImage: (args: any) => Promise<Id<"uploadedImages">>
+  generateUploadUrl: (args: {
+    sessionId: Id<"paintingSessions">
+    guestKey?: string
+  }) => Promise<string>,
+  uploadImage: (args: UploadImageMutationArgs) => Promise<Id<"uploadedImages">>
 ): Promise<ImageUploadResult> {
-  const { sessionId, userId, canvasWidth = 800, canvasHeight = 600, onImageUploaded } = options
+  const { sessionId, guestKey, canvasWidth = 800, canvasHeight = 600, onImageUploaded } = options
 
   try {
     // Validate file
@@ -126,11 +143,11 @@ export async function uploadImageFile(
     const originalDimensions = await getImageDimensions(file)
     
     // Preserve original resolution: always upload the original file and record its natural dimensions
-    let fileToUpload: File | Blob = file
-    let finalDimensions = originalDimensions
+    const fileToUpload: File | Blob = file
+    const finalDimensions = originalDimensions
     
     // Generate upload URL
-    const uploadUrl = await generateUploadUrl()
+    const uploadUrl = await generateUploadUrl({ sessionId, guestKey })
     
     // Upload to Convex storage
     const response = await fetch(uploadUrl, {
@@ -143,14 +160,14 @@ export async function uploadImageFile(
       throw new Error('Failed to upload file')
     }
 
-    const { storageId } = await response.json()
+    const { storageId } = await response.json() as { storageId: Id<"_storage"> }
 
     // Center the image on the canvas
     const x = canvasWidth / 2
     const y = canvasHeight / 2
 
     // Create image record
-    const uploadArgs: any = {
+    const uploadArgs: UploadImageMutationArgs = {
       sessionId,
       storageId,
       filename: file.name,
@@ -161,11 +178,7 @@ export async function uploadImageFile(
       y,
       canvasWidth,
       canvasHeight,
-    }
-    
-    // Only include userId if it's defined and not null
-    if (userId) {
-      uploadArgs.userId = userId
+      guestKey,
     }
     
     const imageId = await uploadImage(uploadArgs)


### PR DESCRIPTION
## Summary

- authorize all public image mutations against their owning painting session
- scope upload URL generation to an authorized session
- propagate guest ownership keys through uploads, transforms, reorders, and deletes
- derive uploaded-image attribution from authenticated server identity instead of caller input
- add regression coverage for owner, outsider, guest, public, and destructive-side-effect cases

## Why

Image mutations previously trusted caller-supplied session or image IDs. A caller who learned an image ID could transform, reorder, or delete images and attached strokes from a private session. Upload URL generation was also globally available, and uploaded-image ownership could be spoofed through a caller-supplied user ID.

## Impact

Private image operations now require the signed-in owner or matching guest key. Public sessions preserve their existing anonymous collaboration behavior. Frontend and backend changes should deploy together because the upload mutation contracts changed.

Unified layer reordering is intentionally handled by a separate paint-layer authorization PR because the active path lives in `convex/layers.ts` rather than `convex/images.ts`.

## Validation

- app TypeScript check
- Convex TypeScript check
- full Vitest suite: 30 tests passed
- scoped ESLint: no errors
- independent review of all nine image mutation surfaces
- `git diff --check`
