### PR TITLE
preview: bound content-only canvas capture

### DIFF
--- a/src/components/KonvaCanvas.tsx
+++ b/src/components/KonvaCanvas.tsx
@@ -12,6 +12,13 @@ import { api } from '../../convex/_generated/api'
 import { shouldShowAdminFeatures } from '../utils/environment'
 import { uploadImageFile, validateImageFile, ACCEPTED_TYPES } from '../utils/imageUpload'
 import { useClipboardContext } from '../context/ClipboardContext'
+import {
+  calculateCaptureDimensions,
+  getCapturePreset,
+  getRasterExportPixelRatio,
+  type CanvasCapturePreset,
+  type CanvasCaptureResult,
+} from '../utils/canvasCapture'
 
 const average = (a: number, b: number): number => (a + b) / 2
 
@@ -202,10 +209,12 @@ interface KonvaCanvasProps {
 export interface CanvasRef {
   clear: () => void
   undo: () => void
-  getImageData: () => string | undefined
+  captureContent: (preset: CanvasCapturePreset) => CanvasCaptureResult | undefined
   getDimensions: () => { width: number; height: number }
   forceRedraw: () => void
 }
+
+const CAPTURE_OVERLAY_NAME = 'capture-overlay'
 
 const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>) => {
   const {
@@ -1123,64 +1132,53 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
     undo: () => {
       // console.warn('KonvaCanvas.undo() is deprecated. Use session-level undo instead.')
     },
-    getImageData: () => {
+    captureContent: (preset) => {
       const stage = stageRef.current
-      if (!stage) {
-        return ''
+      if (!stage || stage.width() <= 0 || stage.height() <= 0) {
+        return undefined
       }
-      
-      try {
-        // Determine export pixel ratio based on the most downscaled visible image
-        const imgScales: number[] = []
-        if (images && Array.isArray(images)) {
-          images.forEach((img: any) => {
-            if (img && typeof img.scale === 'number' && (img.opacity === undefined || img.opacity > 0)) {
-              imgScales.push(img.scale)
-            }
-          })
-        }
-        if (aiImages && Array.isArray(aiImages)) {
-          aiImages.forEach((img: any) => {
-            if (img && typeof img.scale === 'number' && (img.opacity === undefined || img.opacity > 0)) {
-              imgScales.push(img.scale)
-            }
-          })
-        }
-        const minScale = imgScales.length ? Math.min(...imgScales) : 1
-        // Export at native pixels of the smallest-scaled image; never downscale
-        const exportPixelRatio = Math.max(1, (minScale > 0 && isFinite(minScale)) ? (1 / minScale) : 1)
 
-        // Ensure latest render before capture
-        stage.batchDraw()
-        
-        // Render stage to high-res canvas
-        const stageCanvas = stage.toCanvas({ pixelRatio: exportPixelRatio })
-        
-        // Create a temporary canvas with white background at the export size
+      const visibleLayerIds = new Set(layers.filter((layer) => layer.visible).map((layer) => layer.id))
+      const rasterScales = [...(images ?? []), ...(aiImages ?? [])]
+        .filter((image) => visibleLayerIds.has(image._id))
+        .flatMap((image) => [image.scaleX ?? image.scale, image.scaleY ?? image.scale])
+        .filter((scale): scale is number => typeof scale === 'number')
+      const captureDimensions = calculateCaptureDimensions({
+        width: stage.width(),
+        height: stage.height(),
+        preset,
+        desiredPixelRatio: preset === 'export' ? getRasterExportPixelRatio(rasterScales) : undefined,
+      })
+      if (!captureDimensions) return undefined
+
+      const overlayNodes = stage.find(`.${CAPTURE_OVERLAY_NAME}`)
+      const overlayVisibility = overlayNodes.map((node) => node.visible())
+
+      try {
+        overlayNodes.forEach((node) => node.visible(false))
+
+        const stageCanvas = stage.toCanvas({ pixelRatio: captureDimensions.pixelRatio })
         const tempCanvas = document.createElement('canvas')
         tempCanvas.width = stageCanvas.width
         tempCanvas.height = stageCanvas.height
         const tempCtx = tempCanvas.getContext('2d')
-        
-        if (tempCtx) {
-          // Fill with white background (avoid transparent PNG checkerboard look)
-          tempCtx.fillStyle = 'white'
-          tempCtx.fillRect(0, 0, tempCanvas.width, tempCanvas.height)
-          
-          // Draw the stage content on top
-          tempCtx.drawImage(stageCanvas, 0, 0)
-          
-          // Return PNG data URL
-          return tempCanvas.toDataURL('image/png')
+
+        if (!tempCtx) return undefined
+
+        tempCtx.fillStyle = 'white'
+        tempCtx.fillRect(0, 0, tempCanvas.width, tempCanvas.height)
+        tempCtx.drawImage(stageCanvas, 0, 0)
+
+        const config = getCapturePreset(preset)
+        return {
+          dataUrl: tempCanvas.toDataURL(config.mimeType, config.quality),
+          width: tempCanvas.width,
+          height: tempCanvas.height,
         }
-        
-        // Fallback to Konva direct export
-        return stage.toDataURL({ 
-          pixelRatio: exportPixelRatio,
-          mimeType: 'image/png'
-        })
       } catch {
-        return ''
+        return undefined
+      } finally {
+        overlayNodes.forEach((node, index) => node.visible(overlayVisibility[index]))
       }
     },
     getDimensions: () => {
@@ -1206,7 +1204,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
         stageRef.current.batchDraw()
       }
     },
-  }), [dimensions, images, aiImages])
+  }), [dimensions, images, aiImages, layers])
 
   // Find layer info
   const getLayerInfo = (layerId: string) => {
@@ -1613,6 +1611,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
                               segments.push(
                                 <Path
                                   key={`live-${segmentStartIdx}`}
+                                  name={CAPTURE_OVERLAY_NAME}
                                   data={pathData}
                                   fill={rainbowColor}
                                   opacity={opacity}
@@ -1631,6 +1630,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
                       // Normal stroke
                       return (
                         <Path
+                          name={CAPTURE_OVERLAY_NAME}
                           data={strokeResult.pathData}
                           fill={selectedTool === 'eraser' ? '#000000' : color}
                           opacity={opacity}
@@ -1799,6 +1799,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
                     {/* Render current eraser stroke if erasing this layer */}
                     {isDrawing && currentStroke.length > 0 && selectedTool === 'eraser' && activeLayerId === layer.id && (
                       <Path
+                        name={CAPTURE_OVERLAY_NAME}
                         data={getStrokePathData({
                           points: currentStroke,
                           color: '#000000',
@@ -1814,6 +1815,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
                     {/* Render current brush stroke if painting this image layer */}
                     {isDrawing && currentStroke.length > 0 && selectedTool === 'brush' && activeLayerId === layer.id && (
                       <Path
+                        name={CAPTURE_OVERLAY_NAME}
                         data={getStrokePathData({
                           points: currentStroke,
                           color,
@@ -1987,6 +1989,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
                     {/* Render current eraser stroke if erasing this layer */}
                     {isDrawing && currentStroke.length > 0 && selectedTool === 'eraser' && activeLayerId === layer.id && (
                       <Path
+                        name={CAPTURE_OVERLAY_NAME}
                         data={getStrokePathData({
                           points: currentStroke,
                           color: '#000000',
@@ -2002,6 +2005,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
                     {/* Render current brush stroke if painting this AI image layer */}
                     {isDrawing && currentStroke.length > 0 && selectedTool === 'brush' && activeLayerId === layer.id && (
                       <Path
+                        name={CAPTURE_OVERLAY_NAME}
                         data={getStrokePathData({
                           points: currentStroke,
                           color,
@@ -2025,7 +2029,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
             })}
 
           {/* Drawing layer for live strokes and cursors */}
-          <Layer ref={drawingLayerRef} listening={false}>
+          <Layer ref={drawingLayerRef} name={CAPTURE_OVERLAY_NAME} listening={false}>
             {/* Current stroke being drawn (only for non-eraser tools on non-paint layers) */}
             {isDrawing && currentStroke.length > 0 && selectedTool === 'brush' && 
               (() => {
@@ -2208,7 +2212,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
           </Layer>
         {/* Shared transformer for transform tool (render on top for hit-testing) */}
         {selectedTool === 'transform' && (
-          <Layer>
+          <Layer name={CAPTURE_OVERLAY_NAME}>
             <Transformer
               ref={transformerRef}
               rotateEnabled

--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -58,7 +58,7 @@ function BackgroundRemovalModalWrapper({
         
         setTimeout(() => {
           if (canvasRef.current) {
-            const data = canvasRef.current.getImageData() || ''
+            const data = canvasRef.current.captureContent('processing')?.dataUrl || ''
             setCanvasData(data)
             setIsLoading(false)
           }
@@ -130,7 +130,7 @@ function AIGenerationModalWrapper({
         // Wait a bit after forcing redraw
         setTimeout(() => {
           if (canvasRef.current) {
-            const data = canvasRef.current.getImageData() || ''
+            const data = canvasRef.current.captureContent('processing')?.dataUrl || ''
             const dims = canvasRef.current.getDimensions() || { width: 800, height: 600 }
             
             // console.log('[AIGenerationModalWrapper] Canvas data captured after redraw:', data.length)
@@ -142,7 +142,7 @@ function AIGenerationModalWrapper({
             if (!data || data.length === 0) {
               console.warn('[AIGenerationModalWrapper] Canvas data empty, retrying...')
               setTimeout(() => {
-                const retryData = canvasRef.current?.getImageData() || ''
+                const retryData = canvasRef.current?.captureContent('processing')?.dataUrl || ''
                 if (retryData && retryData.length > 0) {
                   // console.log('[AIGenerationModalWrapper] Retry successful:', retryData.length)
                   setCanvasData(retryData)
@@ -218,8 +218,6 @@ export function PaintingView() {
   const startCap = true
   const endCap = true
 
-  const [history, setHistory] = useState<string[]>([])
-  const [historyIndex, setHistoryIndex] = useState(-1)
   const [sessionId, setSessionId] = useState<Id<"paintingSessions"> | null>(null)
   const [showImageUpload, setShowImageUpload] = useState(false)
   const [showAIGeneration, setShowAIGeneration] = useState(false)
@@ -500,19 +498,9 @@ export function PaintingView() {
   useEffect(() => {
     setHasLocalStrokes(false)
     setPendingUndoStrokeIds(new Set())
-    setHistory([])
-    setHistoryIndex(-1)
   }, [sessionId])
 
   const handleStrokeEnd = () => {
-    // Save canvas state for undo/redo
-    const imageData = canvasRef.current?.getImageData()
-    if (imageData) {
-      const newHistory = history.slice(0, historyIndex + 1)
-      newHistory.push(imageData)
-      setHistory(newHistory)
-      setHistoryIndex(newHistory.length - 1)
-    }
     // Mark that we have at least one local stroke in this session
     setHasLocalStrokes(true)
     
@@ -604,8 +592,6 @@ export function PaintingView() {
   const handleClear = async () => {
     // Clear local canvas immediately for responsiveness
     canvasRef.current?.clear()
-    setHistory([])
-    setHistoryIndex(-1)
     setHasLocalStrokes(false)
     
     // Clear the session in the backend
@@ -617,17 +603,17 @@ export function PaintingView() {
   }
 
   const handleExport = () => {
-    const imageData = canvasRef.current?.getImageData()
-    if (imageData) {
+    const capture = canvasRef.current?.captureContent('export')
+    if (capture) {
       // On iOS, show the export modal instead of direct download
       if (isIOS()) {
-        setExportCanvasDataUrl(imageData)
+        setExportCanvasDataUrl(capture.dataUrl)
         setShowExportModal(true)
       } else {
         // Non-iOS devices: use direct download
         const link = document.createElement('a')
         link.download = `wepaintai-${Date.now()}.png`
-        link.href = imageData
+        link.href = capture.dataUrl
         link.click()
       }
       

--- a/src/hooks/useThumbnailGenerator.ts
+++ b/src/hooks/useThumbnailGenerator.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useMutation } from 'convex/react'
 import { api } from '../../convex/_generated/api'
 import { Id } from '../../convex/_generated/dataModel'
@@ -6,181 +6,132 @@ import type { CanvasRef } from '../components/KonvaCanvas'
 import { getGuestKey } from '../utils/guestKey'
 
 interface UseThumbnailGeneratorOptions {
-  sessionId?: Id<"paintingSessions">
+  sessionId?: Id<'paintingSessions'>
   canvasRef: React.RefObject<CanvasRef | null>
-  interval?: number // Default: 30 seconds
+  interval?: number
   enabled?: boolean
+}
+
+async function isAllWhiteThumbnail(dataUrl: string): Promise<boolean> {
+  const image = new Image()
+  await new Promise<void>((resolve, reject) => {
+    image.onload = () => resolve()
+    image.onerror = () => reject(new Error('Failed to decode canvas thumbnail'))
+    image.src = dataUrl
+  })
+
+  const canvas = document.createElement('canvas')
+  canvas.width = image.width
+  canvas.height = image.height
+  const context = canvas.getContext('2d')
+  if (!context) return false
+
+  context.drawImage(image, 0, 0)
+  const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data
+  for (let index = 0; index < pixels.length; index += 4) {
+    if (pixels[index] !== 255 || pixels[index + 1] !== 255 || pixels[index + 2] !== 255) {
+      return false
+    }
+  }
+
+  return true
 }
 
 export function useThumbnailGenerator({
   sessionId,
   canvasRef,
-  interval = 30000, // 30 seconds default
-  enabled = true
+  interval = 30000,
+  enabled = true,
 }: UseThumbnailGeneratorOptions) {
   const updateThumbnail = useMutation(api.paintingSessions.updateSessionThumbnail)
-  const lastThumbnailRef = useRef<string>('')
-  const intervalRef = useRef<NodeJS.Timeout | undefined>(undefined)
+  const lastThumbnailRef = useRef('')
+  const inFlightRef = useRef<Promise<void> | null>(null)
+  const pendingSkipBlankRef = useRef<boolean | null>(null)
+  const activeSessionRef = useRef(sessionId)
 
   useEffect(() => {
-    if (!enabled || !sessionId) {
-      console.log('[ThumbnailGenerator] Not enabled or no sessionId:', { enabled, sessionId })
-      return
-    }
+    activeSessionRef.current = sessionId
+    lastThumbnailRef.current = ''
+    inFlightRef.current = null
+    pendingSkipBlankRef.current = null
+  }, [sessionId])
 
-    const generateThumbnail = async () => {
-      try {
-        console.log('[ThumbnailGenerator] Generating thumbnail for session:', sessionId)
-        
-        // Check if canvas ref is available
-        if (!canvasRef.current) {
-          console.log('[ThumbnailGenerator] Canvas ref not available yet')
-          return
-        }
-        
-        // Get the canvas image data
-        const imageData = canvasRef.current?.getImageData?.()
-        if (!imageData) {
-          console.log('[ThumbnailGenerator] No image data from canvas')
-          return
-        }
-        
-        console.log('[ThumbnailGenerator] Got image data, creating thumbnail...')
-
-        // Check if the image has changed
-        if (imageData === lastThumbnailRef.current) {
-          return // No changes, skip update
-        }
-
-        // Create a smaller thumbnail (max 400px wide)
-        const img = new Image()
-        img.onload = async () => {
-          // Check if the canvas is not empty (all white)
-          const tempCanvas = document.createElement('canvas')
-          tempCanvas.width = img.width
-          tempCanvas.height = img.height
-          const tempCtx = tempCanvas.getContext('2d')
-          
-          if (tempCtx) {
-            tempCtx.drawImage(img, 0, 0)
-            const imageData = tempCtx.getImageData(0, 0, tempCanvas.width, tempCanvas.height)
-            const pixels = imageData.data
-            
-            // Check if all pixels are white
-            let isAllWhite = true
-            for (let i = 0; i < pixels.length; i += 4) {
-              // Check RGB values (ignore alpha)
-              if (pixels[i] !== 255 || pixels[i + 1] !== 255 || pixels[i + 2] !== 255) {
-                isAllWhite = false
-                break
-              }
-            }
-            
-            if (isAllWhite) {
-              console.log('[ThumbnailGenerator] Canvas is empty (all white), skipping thumbnail update')
-              return
-            }
-          }
-          const maxWidth = 400
-          const scale = Math.min(1, maxWidth / img.width)
-          const width = img.width * scale
-          const height = img.height * scale
-
-          // Create a small canvas for the thumbnail
-          const thumbnailCanvas = document.createElement('canvas')
-          thumbnailCanvas.width = width
-          thumbnailCanvas.height = height
-          const ctx = thumbnailCanvas.getContext('2d')
-          
-          if (ctx) {
-            // Draw white background
-            ctx.fillStyle = 'white'
-            ctx.fillRect(0, 0, width, height)
-            
-            // Draw the image
-            ctx.drawImage(img, 0, 0, width, height)
-            
-            // Get the thumbnail data URL (JPEG for smaller size)
-            const thumbnailData = thumbnailCanvas.toDataURL('image/jpeg', 0.8)
-            
-            // Update only if changed
-            if (thumbnailData !== lastThumbnailRef.current) {
-              lastThumbnailRef.current = thumbnailData
-              
-              // Update the thumbnail in the database
-              await updateThumbnail({
-                sessionId,
-                thumbnailUrl: thumbnailData,
-                guestKey: getGuestKey(sessionId) || undefined
-              })
-              console.log('[ThumbnailGenerator] Thumbnail updated successfully')
-            }
-          }
-        }
-        img.src = imageData
-      } catch (error) {
-        console.error('[ThumbnailGenerator] Error generating thumbnail:', error)
+  const generateThumbnail = useCallback(
+    async (skipBlank: boolean) => {
+      if (!sessionId || !canvasRef.current) return
+      if (inFlightRef.current) {
+        pendingSkipBlankRef.current =
+          pendingSkipBlankRef.current === null
+            ? skipBlank
+            : pendingSkipBlankRef.current && skipBlank
+        return inFlightRef.current
       }
-    }
 
-    // Delay initial thumbnail generation to allow strokes to load
-    const initialTimer = setTimeout(() => {
-      console.log('[ThumbnailGenerator] Initial thumbnail generation after delay')
-      generateThumbnail()
-    }, 3000) // 3 second delay for initial load
+      const targetSessionId = sessionId
+      pendingSkipBlankRef.current = null
+      let task: Promise<void>
+      task = Promise.resolve().then(async () => {
+        let nextSkipBlank = skipBlank
 
-    // Set up interval for periodic updates
-    intervalRef.current = setInterval(generateThumbnail, interval)
+        try {
+          while (activeSessionRef.current === targetSessionId) {
+            try {
+              const capture = canvasRef.current?.captureContent('thumbnail')
+              if (capture && capture.dataUrl !== lastThumbnailRef.current) {
+                const shouldSkip = nextSkipBlank && (await isAllWhiteThumbnail(capture.dataUrl))
+                if (!shouldSkip && activeSessionRef.current === targetSessionId) {
+                  await updateThumbnail({
+                    sessionId: targetSessionId,
+                    thumbnailUrl: capture.dataUrl,
+                    guestKey: getGuestKey(targetSessionId) || undefined,
+                  })
+
+                  if (activeSessionRef.current === targetSessionId) {
+                    lastThumbnailRef.current = capture.dataUrl
+                  }
+                }
+              }
+            } catch (error) {
+              console.error('[ThumbnailGenerator] Error generating thumbnail:', error)
+            }
+
+            if (activeSessionRef.current !== targetSessionId) return
+
+            const pendingSkipBlank = pendingSkipBlankRef.current
+            if (pendingSkipBlank === null) return
+            pendingSkipBlankRef.current = null
+            nextSkipBlank = pendingSkipBlank
+          }
+        } finally {
+          if (inFlightRef.current === task) {
+            inFlightRef.current = null
+          }
+        }
+      })
+
+      inFlightRef.current = task
+      await task
+    },
+    [canvasRef, sessionId, updateThumbnail]
+  )
+
+  useEffect(() => {
+    if (!enabled || !sessionId) return
+
+    const initialTimer = window.setTimeout(() => {
+      void generateThumbnail(true)
+    }, 3000)
+    const intervalTimer = window.setInterval(() => {
+      void generateThumbnail(true)
+    }, interval)
 
     return () => {
-      clearTimeout(initialTimer)
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-      }
+      window.clearTimeout(initialTimer)
+      window.clearInterval(intervalTimer)
     }
-  }, [sessionId, canvasRef, interval, enabled, updateThumbnail])
+  }, [enabled, generateThumbnail, interval, sessionId])
 
-  // Manual trigger for thumbnail generation (e.g., on significant changes)
-  const generateNow = async () => {
-    if (!sessionId || !canvasRef.current) return
-
-    try {
-      const imageData = canvasRef.current?.getImageData?.()
-      if (!imageData) return
-
-      // Same thumbnail generation logic as above
-      const img = new Image()
-      img.onload = async () => {
-        const maxWidth = 400
-        const scale = Math.min(1, maxWidth / img.width)
-        const width = img.width * scale
-        const height = img.height * scale
-
-        const thumbnailCanvas = document.createElement('canvas')
-        thumbnailCanvas.width = width
-        thumbnailCanvas.height = height
-        const ctx = thumbnailCanvas.getContext('2d')
-        
-        if (ctx) {
-          ctx.fillStyle = 'white'
-          ctx.fillRect(0, 0, width, height)
-          ctx.drawImage(img, 0, 0, width, height)
-          
-          const thumbnailData = thumbnailCanvas.toDataURL('image/jpeg', 0.8)
-          lastThumbnailRef.current = thumbnailData
-          
-          await updateThumbnail({
-            sessionId,
-            thumbnailUrl: thumbnailData,
-            guestKey: getGuestKey(sessionId) || undefined
-          })
-        }
-      }
-      img.src = imageData
-    } catch (error) {
-      console.error('[ThumbnailGenerator] Error generating thumbnail:', error)
-    }
-  }
+  const generateNow = useCallback(() => generateThumbnail(false), [generateThumbnail])
 
   return { generateNow }
 }

--- a/src/utils/canvasCapture.test.ts
+++ b/src/utils/canvasCapture.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest'
+import { calculateCaptureDimensions, getRasterExportPixelRatio } from './canvasCapture'
+
+describe('calculateCaptureDimensions', () => {
+  test('bounds a landscape thumbnail to 400 pixels wide', () => {
+    expect(calculateCaptureDimensions({ width: 1600, height: 900, preset: 'thumbnail' })).toEqual({
+      pixelRatio: 0.25,
+      width: 400,
+      height: 225,
+    })
+  })
+
+  test('bounds a portrait thumbnail on height as well as width', () => {
+    expect(calculateCaptureDimensions({ width: 600, height: 2400, preset: 'thumbnail' })).toEqual({
+      pixelRatio: 1 / 6,
+      width: 100,
+      height: 400,
+    })
+  })
+
+  test('does not upscale small thumbnails', () => {
+    expect(calculateCaptureDimensions({ width: 200, height: 150, preset: 'thumbnail' })).toEqual({
+      pixelRatio: 1,
+      width: 200,
+      height: 150,
+    })
+  })
+
+  test('caps export resolution even when raster content is heavily downscaled', () => {
+    expect(
+      calculateCaptureDimensions({
+        width: 800,
+        height: 600,
+        preset: 'export',
+        desiredPixelRatio: getRasterExportPixelRatio([0.01]),
+      })
+    ).toEqual({ pixelRatio: 4, width: 3200, height: 2400 })
+  })
+
+  test('constrains large exports by their maximum dimension', () => {
+    const result = calculateCaptureDimensions({
+      width: 3000,
+      height: 2000,
+      preset: 'export',
+      desiredPixelRatio: 4,
+    })
+
+    expect(result?.width).toBe(4096)
+    expect(result?.height).toBe(2731)
+    expect((result?.width ?? 0) * (result?.height ?? 0)).toBeLessThanOrEqual(16 * 1024 * 1024)
+  })
+
+  test('rejects invalid canvas dimensions', () => {
+    expect(calculateCaptureDimensions({ width: 0, height: 600, preset: 'export' })).toBeUndefined()
+    expect(
+      calculateCaptureDimensions({ width: Number.NaN, height: 600, preset: 'export' })
+    ).toBeUndefined()
+  })
+})
+
+describe('getRasterExportPixelRatio', () => {
+  test('uses both scale axes while ignoring invalid transforms', () => {
+    expect(getRasterExportPixelRatio([2, 0.25, 0, Number.NaN, -0.5])).toBe(4)
+  })
+})

--- a/src/utils/canvasCapture.ts
+++ b/src/utils/canvasCapture.ts
@@ -1,0 +1,105 @@
+export type CanvasCapturePreset = 'thumbnail' | 'processing' | 'export'
+
+export interface CanvasCaptureResult {
+  dataUrl: string
+  width: number
+  height: number
+}
+
+interface CapturePresetConfig {
+  mimeType: 'image/png' | 'image/jpeg'
+  quality?: number
+  desiredPixelRatio: number
+  maxPixelRatio: number
+  maxWidth: number
+  maxHeight: number
+  maxPixels: number
+}
+
+export interface CaptureDimensions {
+  pixelRatio: number
+  width: number
+  height: number
+}
+
+const CAPTURE_PRESETS: Record<CanvasCapturePreset, CapturePresetConfig> = {
+  thumbnail: {
+    mimeType: 'image/jpeg',
+    quality: 0.8,
+    desiredPixelRatio: 1,
+    maxPixelRatio: 1,
+    maxWidth: 400,
+    maxHeight: 400,
+    maxPixels: 400 * 400,
+  },
+  processing: {
+    mimeType: 'image/png',
+    desiredPixelRatio: 1,
+    maxPixelRatio: 1,
+    maxWidth: 2048,
+    maxHeight: 2048,
+    maxPixels: 2048 * 2048,
+  },
+  export: {
+    mimeType: 'image/png',
+    desiredPixelRatio: 1,
+    maxPixelRatio: 4,
+    maxWidth: 4096,
+    maxHeight: 4096,
+    maxPixels: 16 * 1024 * 1024,
+  },
+}
+
+export function getCapturePreset(preset: CanvasCapturePreset): CapturePresetConfig {
+  return CAPTURE_PRESETS[preset]
+}
+
+export function getRasterExportPixelRatio(scales: readonly number[]): number {
+  return scales.reduce((pixelRatio, scale) => {
+    const normalizedScale = Math.abs(scale)
+    if (!Number.isFinite(normalizedScale) || normalizedScale <= 0) {
+      return pixelRatio
+    }
+
+    return Math.max(pixelRatio, 1 / normalizedScale)
+  }, 1)
+}
+
+export function calculateCaptureDimensions({
+  width,
+  height,
+  preset,
+  desiredPixelRatio,
+}: {
+  width: number
+  height: number
+  preset: CanvasCapturePreset
+  desiredPixelRatio?: number
+}): CaptureDimensions | undefined {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return undefined
+  }
+
+  const config = CAPTURE_PRESETS[preset]
+  const requestedRatio =
+    desiredPixelRatio !== undefined && Number.isFinite(desiredPixelRatio) && desiredPixelRatio > 0
+      ? desiredPixelRatio
+      : config.desiredPixelRatio
+  const pixelRatio = Math.min(
+    requestedRatio,
+    config.maxPixelRatio,
+    config.maxWidth / width,
+    config.maxHeight / height,
+    Math.sqrt(config.maxPixels / (width * height))
+  )
+
+  if (!Number.isFinite(pixelRatio) || pixelRatio <= 0) {
+    return undefined
+  }
+
+  return {
+    pixelRatio,
+    width: Math.max(1, Math.round(width * pixelRatio)),
+    height: Math.max(1, Math.round(height * pixelRatio)),
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'edge-runtime',
-    include: ['convex/**/*.test.ts'],
+    include: ['convex/**/*.test.ts', 'src/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## Summary

- replace ambiguous full-stage capture with explicit thumbnail, processing, and export presets
- exclude cursors, live remote strokes, brush indicators, in-progress local strokes, and transformer controls
- cap pixel ratio, dimensions, and total pixels before allocating the capture canvas
- render thumbnails directly at bounded JPEG size instead of downsampling a huge PNG
- coalesce thumbnail requests that arrive while a capture/update is in flight
- remove unused per-stroke full-canvas history snapshots
- add capture sizing tests and include source tests in Vitest discovery

## Why

The previous `getImageData()` path captured every visible Konva stage layer, so Library previews and exports could include collaboration cursors and transform handles. Its pixel ratio was also derived from the smallest image scale without a cap, allowing tiny image scales to allocate enormous canvases before thumbnail downsampling.

## Impact

Persisted previews, AI/background-removal inputs, and exports now contain canvas content only. Thumbnail capture is bounded to 400px, processing capture to 2048px, and export capture to 4x/4096px/16M pixels.

Blank-preview and clear lifecycle semantics remain intentionally separate because they require resolving the current clear-strokes versus clear-canvas behavior.

## Validation

- app TypeScript check
- Convex TypeScript check
- full Vitest suite: 32 tests passed, including 7 capture sizing tests
- full ESLint with `--quiet`: no errors
- independent review and re-review: no capture-scoped blockers
- `git diff --check`
