### PR TITLE
preview: harden redeploy and cleanup

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,7 +1,9 @@
 name: Remove PR preview
 
 on:
-  pull_request:
+  # Run from the trusted default-branch workflow so cleanup still starts when
+  # the PR head branch is deleted immediately after close.
+  pull_request_target:
     types: [closed]
 
 permissions:

--- a/selfhost/preview/deploy-preview.sh
+++ b/selfhost/preview/deploy-preview.sh
@@ -207,8 +207,18 @@ corepack pnpm build
 
 LABEL="com.wepaintai.preview.pr-$PR"
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
-launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
-sleep 1
+SERVICE="gui/$(id -u)/$LABEL"
+launchctl bootout "$SERVICE" 2>/dev/null || true
+
+# launchd may report the service as absent before it has finished unloading.
+# Wait briefly here and also retry bootstrap below so synchronize/reopen
+# deployments cannot fail with launchctl's transient exit 5.
+for _ in $(seq 1 20); do
+  if ! launchctl print "$SERVICE" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
 mkdir -p "$DEST"
 rsync -a --delete .output/ "$DEST/output/"
 
@@ -237,7 +247,20 @@ cat > "$PLIST" <<EOF
 </dict>
 </plist>
 EOF
-launchctl bootstrap "gui/$(id -u)" "$PLIST"
+
+frontend_bootstrapped=""
+bootstrap_error=""
+for attempt in $(seq 1 5); do
+  if bootstrap_error="$(launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>&1)"; then
+    frontend_bootstrapped=1
+    break
+  fi
+  sleep "$attempt"
+done
+if [ -z "$frontend_bootstrapped" ]; then
+  echo "Preview frontend launchd bootstrap failed after 5 attempts: $bootstrap_error" >&2
+  exit 1
+fi
 
 cat > "$ROOT/caddy/pr-$PR.caddy.tmp" <<EOF
 @pr$PR host $FRONTEND_HOST


### PR DESCRIPTION
## Summary

- retry launchd bootstrap after a bounded wait for the previous preview frontend agent to unload
- run close-only cleanup from the trusted default-branch workflow with `pull_request_target`
- preserve same-repository checks and avoid checking out or executing PR code during cleanup

## Root causes

The full-stack E2E found that a synchronize/reopen deployment could reach `launchctl bootstrap` while launchd was still unloading the previous agent, returning transient exit 5. It also found that closing a PR while immediately deleting its head branch could suppress the `pull_request.closed` workflow and strand the slot.

## Validation

- `bash -n` for preview lifecycle scripts
- workflow YAML parsing
- `git diff --check`
- planned live E2E: initial deploy, same-PR redeploy, close with immediate head-branch deletion, slot/container/agent teardown, public 404, and production health
