### PR TITLE
ux: interaction-quality fixes for canvas UI (audit T4/T5/T6/P4)

### DIFF
--- a/src/components/BrushSettingsModal.tsx
+++ b/src/components/BrushSettingsModal.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { X, Brush, Sliders, RotateCcw } from 'lucide-react'
+import React from 'react'
+import { X, Sliders, RotateCcw } from 'lucide-react'
 
 export interface BrushSettings {
   smoothing: number
@@ -61,18 +61,15 @@ const SettingsSlider = ({ label, value, min, max, step, onChange, description }:
 }
 
 export function BrushSettingsModal({ isOpen, onClose, settings, onSettingsChange }: BrushSettingsModalProps) {
-  const [localSettings, setLocalSettings] = useState<BrushSettings>(settings)
-
   if (!isOpen) return null
 
+  // Render directly from the settings prop so external changes (or a reopen
+  // after settings changed elsewhere) never desync the sliders
   const handleSettingChange = (key: keyof BrushSettings, value: number) => {
-    const newSettings = { ...localSettings, [key]: value }
-    setLocalSettings(newSettings)
-    onSettingsChange(newSettings)
+    onSettingsChange({ ...settings, [key]: value })
   }
 
   const handleReset = () => {
-    setLocalSettings(DEFAULT_SETTINGS)
     onSettingsChange(DEFAULT_SETTINGS)
   }
 
@@ -96,7 +93,7 @@ export function BrushSettingsModal({ isOpen, onClose, settings, onSettingsChange
         <div className="space-y-6">
           <SettingsSlider
             label="Smoothing"
-            value={localSettings.smoothing}
+            value={settings.smoothing}
             min={0}
             max={1}
             step={0.05}
@@ -106,7 +103,7 @@ export function BrushSettingsModal({ isOpen, onClose, settings, onSettingsChange
 
           <SettingsSlider
             label="Thinning"
-            value={localSettings.thinning}
+            value={settings.thinning}
             min={-1}
             max={1}
             step={0.05}
@@ -116,7 +113,7 @@ export function BrushSettingsModal({ isOpen, onClose, settings, onSettingsChange
 
           <SettingsSlider
             label="Streamline"
-            value={localSettings.streamline}
+            value={settings.streamline}
             min={0}
             max={1}
             step={0.05}
@@ -126,7 +123,7 @@ export function BrushSettingsModal({ isOpen, onClose, settings, onSettingsChange
 
           <SettingsSlider
             label="Start Taper"
-            value={localSettings.startTaper}
+            value={settings.startTaper}
             min={0}
             max={100}
             step={5}
@@ -136,7 +133,7 @@ export function BrushSettingsModal({ isOpen, onClose, settings, onSettingsChange
 
           <SettingsSlider
             label="End Taper"
-            value={localSettings.endTaper}
+            value={settings.endTaper}
             min={0}
             max={100}
             step={5}

--- a/src/components/KonvaCanvas.tsx
+++ b/src/components/KonvaCanvas.tsx
@@ -20,6 +20,7 @@ import {
   type CanvasCaptureResult,
 } from '../utils/canvasCapture'
 import { getGuestKey } from '../utils/guestKey'
+import { installUnloadGuard, registerUnsavedWorkCounter } from '../lib/unsavedChanges'
 
 const average = (a: number, b: number): number => (a + b) / 2
 
@@ -254,6 +255,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
   const aiImageNodeRefs = useRef<Map<string, Konva.Image>>(new Map())
     
   const [isDrawing, setIsDrawing] = useState(false)
+  const isDrawingRef = useRef(false)
   const [currentStroke, setCurrentStroke] = useState<Point[]>([])
   const [pendingStrokes, setPendingStrokes] = useState<Map<string, LocalStroke>>(new Map())
   const strokeEndedRef = useRef(false)
@@ -454,6 +456,16 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
       }
     })
   }, [aiImages, dimensions.width, dimensions.height, updateAIImageTransform, guestKey])
+
+  // Warn before tab close while a stroke is mid-draw or still syncing
+  // (in-flight/queued strokes are counted in unsavedChanges/syncStatus)
+  useEffect(() => {
+    isDrawingRef.current = isDrawing
+  }, [isDrawing])
+  useEffect(() => {
+    installUnloadGuard()
+    return registerUnsavedWorkCounter(() => (isDrawingRef.current ? 1 : 0))
+  }, [])
 
   // Remove confirmed strokes from pending when they appear in the strokes array
   useEffect(() => {
@@ -2161,10 +2173,14 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
             {/* Cursor size indicator */}
             {(() => {
               const activeLayer = layers.find(l => l.id === activeLayerId)
-              const isDisabled = !!activeLayer && activeLayer.visible === false && (selectedTool === 'brush' || selectedTool === 'eraser')
+              const hiddenLayer = !!activeLayer && activeLayer.visible === false && (selectedTool === 'brush' || selectedTool === 'eraser')
+              // Mirror the handlePointerDown guard: erasing only works on paint/image/ai-image layers
+              const eraserInvalidLayer = selectedTool === 'eraser' &&
+                (!activeLayer || !['paint', 'image', 'ai-image'].includes(activeLayer.type))
+              const isDisabled = hiddenLayer || eraserInvalidLayer
               if (!cursorPosition || !isMouseOverCanvas || (selectedTool !== 'brush' && selectedTool !== 'eraser')) return null
               if (isDisabled) {
-                // Show a red X to indicate disabled tool on hidden layer
+                // Show a red X to indicate the tool can't act on the active layer
                 const len = Math.max(12, size) // ensure visible even for tiny brush sizes
                 const half = len / 2
                 return (

--- a/src/components/LibraryModal.tsx
+++ b/src/components/LibraryModal.tsx
@@ -9,6 +9,8 @@ interface LibraryModalProps {
   isOpen: boolean
   onClose: () => void
   onCreateNew: () => void
+  /** Client-side session switch (avoids a full page reload when provided) */
+  onOpenSession?: (sessionId: Id<'paintingSessions'>) => void
 }
 
 interface SessionWithThumbnail {
@@ -20,7 +22,7 @@ interface SessionWithThumbnail {
   strokeCounter: number
 }
 
-export function LibraryModal({ isOpen, onClose, onCreateNew }: LibraryModalProps) {
+export function LibraryModal({ isOpen, onClose, onCreateNew, onOpenSession }: LibraryModalProps) {
   const navigate = useNavigate()
   const [searchQuery, setSearchQuery] = React.useState('')
   const [editingSessionId, setEditingSessionId] = React.useState<Id<"paintingSessions"> | null>(null)
@@ -45,8 +47,13 @@ export function LibraryModal({ isOpen, onClose, onCreateNew }: LibraryModalProps
   })
 
   const handleOpenSession = (sessionId: Id<"paintingSessions">) => {
-    // Use window.location to force a full page navigation
-    window.location.href = `/?session=${sessionId}`
+    if (onOpenSession) {
+      // Client-side switch — no full page reload
+      onOpenSession(sessionId)
+    } else {
+      // Fallback: full page navigation
+      window.location.href = `/?session=${sessionId}`
+    }
     onClose()
   }
 
@@ -108,9 +115,14 @@ export function LibraryModal({ isOpen, onClose, onCreateNew }: LibraryModalProps
         isPublic: false
       })
       console.log('[LibraryModal] Created session:', newSessionId)
-      
+
       // Navigate to the new session
-      window.location.href = `/?session=${newSessionId}`
+      if (onOpenSession) {
+        onOpenSession(newSessionId)
+        onClose()
+      } else {
+        window.location.href = `/?session=${newSessionId}`
+      }
     } catch (error) {
       console.error('[LibraryModal] Error creating session:', error)
       // Fallback to the original behavior

--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -29,7 +29,6 @@ import { api } from '../../convex/_generated/api'
 import { useThumbnailGenerator } from '../hooks/useThumbnailGenerator'
 import { ClipboardProvider } from '../context/ClipboardContext'
 import { getCurrentGuestSession, setCurrentGuestSession, clearCurrentGuestSession, getGuestKey, touchRecentGuestSession, removeRecentGuestSession } from '../utils/guestKey'
-import { startNewCanvas } from '../utils/newCanvas'
 
 // Wrapper component for background removal modal
 function BackgroundRemovalModalWrapper({ 
@@ -234,6 +233,20 @@ export function PaintingView() {
   // Mutation state to prevent concurrent operations
   const [isMutating, setIsMutating] = useState(false)
   const lastMutationTime = useRef(0)
+  // Busy states so async action buttons disable instead of eating clicks
+  const [isClearing, setIsClearing] = useState(false)
+  const [isExporting, setIsExporting] = useState(false)
+
+  // Keep isMutating true through the undo/redo rate-limit window so the
+  // buttons' disabled state matches the guard instead of eating clicks
+  const releaseMutationLock = useCallback(() => {
+    const remaining = lastMutationTime.current + 100 - Date.now()
+    if (remaining > 0) {
+      setTimeout(() => setIsMutating(false), remaining)
+    } else {
+      setIsMutating(false)
+    }
+  }, [])
   
   // Optimistic UI state for undo operations
   const [pendingUndoStrokeIds, setPendingUndoStrokeIds] = useState<Set<string>>(new Set())
@@ -459,10 +472,26 @@ export function PaintingView() {
     }
   }, [sessionId, sessionStatus, effectiveIsSignedIn, session?.name])
 
-  // Leave the broken session behind so a fresh painting is created
-  const startNewPainting = useCallback(() => {
-    startNewCanvas()
+  // Switch to another session (or null to create a fresh one) without a full
+  // page reload: update the URL via history and let React state drive the swap.
+  const switchToSession = useCallback((newSessionId: Id<"paintingSessions"> | null) => {
+    try {
+      const url = new URL(window.location.href)
+      if (newSessionId) {
+        url.searchParams.set('session', newSessionId)
+      } else {
+        url.searchParams.delete('session')
+      }
+      window.history.replaceState({}, '', url.toString())
+    } catch {}
+    setSessionId(newSessionId)
   }, [])
+
+  // Leave the current session behind so a fresh painting is created
+  const startNewPainting = useCallback(() => {
+    clearCurrentGuestSession()
+    switchToSession(null)
+  }, [switchToSession])
 
   // Keep URL masked for guest-owned sessions; show for others and signed-in users
   useEffect(() => {
@@ -495,10 +524,12 @@ export function PaintingView() {
     } catch {}
   }, [sessionId, currentUser.id])
 
-  // Reset transient undo state when switching sessions
+  // Reset transient per-session state when switching sessions
   useEffect(() => {
     setHasLocalStrokes(false)
     setPendingUndoStrokeIds(new Set())
+    setActiveLayerId(undefined)
+    setActivePaintLayerId(null)
   }, [sessionId])
 
   const handleStrokeEnd = () => {
@@ -557,7 +588,7 @@ export function PaintingView() {
         })
       }
     } finally {
-      setIsMutating(false)
+      releaseMutationLock()
       // Clear pending undo set after operation completes
       if (lastStrokeId) {
         setPendingUndoStrokeIds(prev => {
@@ -586,40 +617,52 @@ export function PaintingView() {
       console.error('Failed to redo stroke:', error)
       // The UI will automatically update based on the query state
     } finally {
-      setIsMutating(false)
+      releaseMutationLock()
     }
   }
 
   const handleClear = async () => {
+    if (isClearing) return
+    setIsClearing(true)
     // Clear local canvas immediately for responsiveness
     canvasRef.current?.clear()
     setHasLocalStrokes(false)
-    
+
     // Clear the session in the backend
     try {
       await clearSession()
     } catch (error) {
       console.error('Failed to clear session:', error)
+    } finally {
+      setIsClearing(false)
     }
   }
 
   const handleExport = () => {
-    const capture = canvasRef.current?.captureContent('export')
-    if (capture) {
-      // On iOS, show the export modal instead of direct download
-      if (isIOS()) {
-        setExportCanvasDataUrl(capture.dataUrl)
-        setShowExportModal(true)
-      } else {
-        // Non-iOS devices: use direct download
-        const link = document.createElement('a')
-        link.download = `wepaintai-${Date.now()}.png`
-        link.href = capture.dataUrl
-        link.click()
+    if (isExporting) return
+    setIsExporting(true)
+    try {
+      const capture = canvasRef.current?.captureContent('export')
+      if (capture) {
+        // On iOS, show the export modal instead of direct download
+        if (isIOS()) {
+          setExportCanvasDataUrl(capture.dataUrl)
+          setShowExportModal(true)
+        } else {
+          // Non-iOS devices: use direct download
+          const link = document.createElement('a')
+          link.download = `wepaintai-${Date.now()}.png`
+          link.href = capture.dataUrl
+          link.click()
+        }
+
+        // Generate thumbnail after export
+        generateThumbnail()
       }
-      
-      // Generate thumbnail after export
-      generateThumbnail()
+    } finally {
+      // Capture is synchronous; hold the busy state briefly so a double-click
+      // can't trigger a second download
+      setTimeout(() => setIsExporting(false), 600)
     }
   }
 
@@ -1173,6 +1216,10 @@ export function PaintingView() {
         onRedo={handleRedo}
         onClear={handleClear}
         onExport={handleExport}
+        isClearing={isClearing}
+        isExporting={isExporting}
+        onNewCanvas={startNewPainting}
+        onOpenSession={(id) => switchToSession(id)}
         onImageUpload={handleImageUpload}
         onAIGenerate={handleAIGenerate}
         onBackgroundRemoval={handleBackgroundRemoval}

--- a/src/components/ToolPanel.tsx
+++ b/src/components/ToolPanel.tsx
@@ -26,7 +26,8 @@ import {
   Library,
   Sliders,
   Merge,
-  Scan
+  Scan,
+  Loader2
 } from 'lucide-react'
 import { AuthModal } from './AuthModal'
 import { LibraryModal } from './LibraryModal'
@@ -63,6 +64,10 @@ interface ToolPanelProps {
   onRedo: () => void
   onClear: () => void
   onExport: () => void
+  isClearing?: boolean
+  isExporting?: boolean
+  onNewCanvas?: () => void
+  onOpenSession?: (sessionId: Id<'paintingSessions'>) => void
   onImageUpload?: () => void
   onAIGenerate?: () => void
   onBackgroundRemoval?: () => void
@@ -266,20 +271,22 @@ const ActionButton = React.memo(({
   onClick,
   isPrimary = false,
   isDanger = false,
-  disabled = false
+  disabled = false,
+  busy = false
 }: {
   icon: React.ElementType,
   label: string,
   onClick: () => void,
   isPrimary?: boolean,
   isDanger?: boolean,
-  disabled?: boolean
+  disabled?: boolean,
+  busy?: boolean
 }) => (
   <button
     onClick={onClick}
-    disabled={disabled}
+    disabled={disabled || busy}
     className={`w-8 h-8 flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-blue-400 ${
-      disabled
+      disabled || busy
         ? 'bg-white/5 text-white/30 cursor-not-allowed'
         : isDanger
         ? 'bg-red-500 text-white hover:bg-red-600'
@@ -290,7 +297,7 @@ const ActionButton = React.memo(({
     title={label}
     aria-label={label}
   >
-    <Icon className="w-4 h-4" />
+    {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Icon className="w-4 h-4" />}
   </button>
 ))
 
@@ -620,6 +627,10 @@ export function ToolPanel({
   onRedo,
   onClear,
   onExport,
+  isClearing = false,
+  isExporting = false,
+  onNewCanvas,
+  onOpenSession,
   onImageUpload,
   onAIGenerate,
   onBackgroundRemoval,
@@ -1045,15 +1056,29 @@ export function ToolPanel({
 
       {/* Sliders */}
       <div className="border-b border-white/20 mb-2 pb-1">
-        <Slider
-          value={size}
-          min={1}
-          max={100}
-          onChange={onSizeChange}
-          icon={Circle}
-          label="Brush Size"
-          color="hsl(var(--primary))"
-        />
+        <div className="flex items-center gap-1">
+          <div className="flex-1 min-w-0">
+            <Slider
+              value={size}
+              min={1}
+              max={100}
+              onChange={onSizeChange}
+              icon={Circle}
+              label="Brush Size"
+              color="hsl(var(--primary))"
+            />
+          </div>
+          {brushSettings && onBrushSettingsChange && (
+            <button
+              onClick={() => setShowBrushSettings(true)}
+              className="p-1 shrink-0 text-white/60 hover:text-white hover:bg-white/10 rounded transition-colors"
+              title="Brush settings (smoothing, taper, stroke feel)"
+              aria-label="Open brush settings"
+            >
+              <Sliders className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
         <Slider
           value={opacity * 100}
           min={0}
@@ -1076,17 +1101,18 @@ export function ToolPanel({
         <div className="flex justify-center">
           <ActionButton
             icon={X}
-            label={confirmingClear ? 'Click again to confirm' : 'Clear Canvas'}
+            label={isClearing ? 'Clearing…' : confirmingClear ? 'Click again to confirm' : 'Clear Canvas'}
             onClick={handleClearClick}
             isDanger={confirmingClear}
+            busy={isClearing}
           />
         </div>
         <div className="flex justify-center">
-          <ActionButton icon={Save} label="Export" onClick={onExport} />
+          <ActionButton icon={Save} label={isExporting ? 'Exporting…' : 'Export'} onClick={onExport} busy={isExporting} />
         </div>
       </div>
     </>
-  ), [selectedTool, handleToolSelect, effectiveIsSignedIn, color, onColorChange, colorMode, onColorModeChange, size, onSizeChange, opacity, onOpacityChange, onUndo, canUndo, onRedo, canRedo, confirmingClear, handleClearClick, onExport])
+  ), [selectedTool, handleToolSelect, effectiveIsSignedIn, color, onColorChange, colorMode, onColorModeChange, size, onSizeChange, opacity, onOpacityChange, onUndo, canUndo, onRedo, canRedo, confirmingClear, handleClearClick, isClearing, onExport, isExporting, brushSettings, onBrushSettingsChange])
 
   const renderLayersTab = React.useCallback(() => (
     <div className="space-y-2">
@@ -1308,7 +1334,9 @@ export function ToolPanel({
             className="w-full px-3 py-1.5 text-left text-sm text-white hover:bg-white/20 transition-colors flex items-center gap-2"
             onClick={() => {
               setShowMenu(false)
-              startNewCanvas()
+              // Client-side session switch when available; full navigation as fallback
+              if (onNewCanvas) onNewCanvas()
+              else startNewCanvas()
             }}
           >
             <PlusCircle className="w-4 h-4" />
@@ -1474,7 +1502,8 @@ export function ToolPanel({
       <LibraryModal
         isOpen={isLibraryModalOpen}
         onClose={closeLibrary}
-        onCreateNew={startNewCanvas}
+        onCreateNew={onNewCanvas ?? startNewCanvas}
+        onOpenSession={onOpenSession}
       />
       <GuestRecentModal
         isOpen={showGuestRecent}

--- a/src/hooks/usePaintingSession.ts
+++ b/src/hooks/usePaintingSession.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState, useRef, useMemo } from "react";
 import { p2pLogger } from "../lib/p2p-logger";
 import { convexLow } from "../lib/convex";
 import { reportSyncFailure, reportSyncSuccess } from "../lib/syncStatus";
+import { beginInFlightStroke, endInFlightStroke } from "../lib/unsavedChanges";
 import {
   generateGuestKey,
   getGuestKey,
@@ -297,6 +298,7 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
       guestKey: localGuestKey || undefined,
     };
 
+    beginInFlightStroke();
     try {
       const strokeId = await addStroke(strokeArgs);
       reportSyncSuccess();
@@ -307,6 +309,8 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
       console.error('[usePaintingSession] Failed to save stroke:', e);
       reportSyncFailure(e, strokeArgs);
       return undefined;
+    } finally {
+      endInFlightStroke();
     }
   }, [sessionId, addStroke, currentUser, localGuestKey]);
 

--- a/src/lib/syncStatus.ts
+++ b/src/lib/syncStatus.ts
@@ -2,6 +2,7 @@ import { useSyncExternalStore } from "react";
 import type { FunctionArgs } from "convex/server";
 import { api } from "../../convex/_generated/api";
 import { convexHigh } from "./convex";
+import { registerUnsavedWorkCounter } from "./unsavedChanges";
 
 /**
  * Module-level sync failure store shared by every usePaintingSession instance
@@ -37,6 +38,9 @@ let state: SyncStatus = {
 };
 
 const listeners = new Set<() => void>();
+
+// Strokes queued for replay are unsaved work — closing the tab would lose them.
+registerUnsavedWorkCounter(() => pendingStrokes.length);
 
 function setState(partial: Partial<SyncStatus>) {
   state = { ...state, ...partial, pendingStrokeCount: pendingStrokes.length };

--- a/src/lib/unsavedChanges.ts
+++ b/src/lib/unsavedChanges.ts
@@ -1,0 +1,48 @@
+/**
+ * beforeunload guard that warns only while stroke data could still be lost:
+ * a stroke mid-draw, a stroke mutation in flight, or failed strokes queued
+ * for replay (see syncStatus). A fully synced canvas closes freely.
+ */
+
+type Counter = () => number;
+
+let inFlightStrokes = 0;
+const counters = new Set<Counter>();
+
+export function beginInFlightStroke() {
+  inFlightStrokes++;
+}
+
+export function endInFlightStroke() {
+  if (inFlightStrokes > 0) inFlightStrokes--;
+}
+
+/** Register an extra unsaved-work counter; returns an unregister function. */
+export function registerUnsavedWorkCounter(counter: Counter) {
+  counters.add(counter);
+  return () => {
+    counters.delete(counter);
+  };
+}
+
+function hasUnsavedWork(): boolean {
+  if (inFlightStrokes > 0) return true;
+  for (const counter of counters) {
+    if (counter() > 0) return true;
+  }
+  return false;
+}
+
+let installed = false;
+
+/** Idempotent; safe to call from any component effect (client only). */
+export function installUnloadGuard() {
+  if (installed || typeof window === "undefined") return;
+  installed = true;
+  window.addEventListener("beforeunload", (e) => {
+    if (!hasUnsavedWork()) return;
+    e.preventDefault();
+    // Required by some browsers to actually show the prompt
+    e.returnValue = "";
+  });
+}


### PR DESCRIPTION
## What

Six small interaction-quality fixes from the wePaintAI UX audit (minor/polish cluster T4 + T5 + T6 + P4):

1. **beforeunload guard** (new `src/lib/unsavedChanges.ts`): warns before tab close only while stroke data could be lost — a stroke mid-draw (KonvaCanvas), an `addStroke` mutation in flight (usePaintingSession), or failed strokes queued for replay (syncStatus). A fully synced canvas closes without a prompt.
2. **No-reload session switch**: "New Canvas" (⋮ menu) and the Library's "Create New" / open-painting actions previously did `window.location` navigations (white flash). They now switch client-side via `history.replaceState` + a `sessionId` state swap in `PaintingView`; per-session UI state (active layer, undo state) resets on switch. The old full-navigation path remains as a fallback when the new props aren't wired.
3. **Export/Clear busy states**: both ActionButtons now disable and show a spinner while their work runs (Export holds ~600ms since capture is synchronous), preventing double-fires.
4. **Undo dead clicks**: undo/redo already disabled during mutation, but clicks landing in the 100ms rate-limit window after a mutation were silently eaten while the buttons looked enabled. The disabled state now persists through that window, exactly mirroring the guard.
5. **Eraser invalid-layer feedback**: the red-X blocked cursor now also covers erasing on an invalid layer type (anything that isn't paint/image/ai-image, matching the pointer-down guard), not just hidden layers — the eraser never "just does nothing" anymore.
6. **Brush settings discoverability + desync**: added a direct entry point on the Tools tab (sliders icon next to Brush Size), and `BrushSettingsModal` now renders from the `settings` prop instead of a one-shot `useState` copy, so the sliders can no longer desync from external changes.

## Why

These were audit findings about silent no-ops, missing feedback, and unnecessary full page reloads that made the canvas UI feel unreliable.

## Reviewer notes

- `history.replaceState` triggers TanStack Router's root `beforeLoad` (which calls the `getAuth` server function), so each client-side session switch does one auth round trip. The app already used `replaceState` for URL masking, so this is not new exposure; verified both calls return 200 against a local backend.
- The beforeunload counters are intentionally conservative: only in-flight/queued/mid-draw strokes count, so a stale pending-preview entry can't cause a permanent false-positive prompt.
- Verified in the browser: guard fires only while unsynced (synthetic `beforeunload` dispatch), New Canvas keeps a `window` marker alive (no reload) and creates a fresh session, Export shows the busy spinner, Brush Settings reopens with current values.
- `pnpm typecheck` passes; `pnpm lint` has 0 errors (pre-existing warning debt only). No test runner is configured in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)