### PR TITLE
UX polish: export naming/race, upload dimension cap, modal fixes (audit A6)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -29,6 +29,7 @@ import type * as polarPackages from "../polarPackages.js";
 import type * as polarWebhook from "../polarWebhook.js";
 import type * as presence from "../presence.js";
 import type * as previewSeed from "../previewSeed.js";
+import type * as sessionAuth from "../sessionAuth.js";
 import type * as strokes from "../strokes.js";
 import type * as tokenPolicy from "../tokenPolicy.js";
 import type * as tokens from "../tokens.js";
@@ -65,6 +66,7 @@ declare const fullApi: ApiFromModules<{
   polarWebhook: typeof polarWebhook;
   presence: typeof presence;
   previewSeed: typeof previewSeed;
+  sessionAuth: typeof sessionAuth;
   strokes: typeof strokes;
   tokenPolicy: typeof tokenPolicy;
   tokens: typeof tokens;

--- a/src/components/AIGenerationModal.tsx
+++ b/src/components/AIGenerationModal.tsx
@@ -284,15 +284,16 @@ export function AIGenerationModal({
             <button
               onClick={() => setWithFlames(!withFlames)}
               disabled={isGenerating}
+              title={withFlames ? "Removes 'with flames' from your prompt" : "Appends 'with flames' to your prompt"}
               className={`flex items-center gap-2 px-3 py-2 rounded-md border transition-all ${
-                withFlames 
-                  ? 'bg-orange-500/20 border-orange-500/40 text-orange-400 hover:bg-orange-500/30' 
+                withFlames
+                  ? 'bg-orange-500/20 border-orange-500/40 text-orange-400 hover:bg-orange-500/30'
                   : 'bg-white/10 border-white/20 text-white/70 hover:bg-white/20'
               }`}
             >
               <Flame className={`w-4 h-4 ${withFlames ? 'animate-pulse' : ''}`} />
               <span className="text-sm font-medium">
-                {withFlames ? '🔥 ✅' : 'Add 🔥'}
+                {withFlames ? "🔥 'with flames' added" : "Add 'with flames' 🔥"}
               </span>
             </button>
           </div>

--- a/src/components/BackgroundRemovalModal.tsx
+++ b/src/components/BackgroundRemovalModal.tsx
@@ -34,6 +34,12 @@ export function BackgroundRemovalModal({
 
   // Filter layers to only show image and AI image layers
   const selectableLayers = layers.filter(layer => layer.type === 'image' || layer.type === 'ai-image')
+
+  // Preview the selected layer's image when one is chosen, otherwise the full canvas
+  const selectedLayer = selectedLayerId && selectedLayerId !== 'canvas'
+    ? layers.find(l => l.id === selectedLayerId)
+    : undefined
+  const previewUrl = selectedLayer?.thumbnailUrl || canvasDataUrl
   
   // Debug: Log available layers
   console.log('BackgroundRemovalModal - All layers:', layers)
@@ -170,9 +176,9 @@ export function BackgroundRemovalModal({
 
           {/* Preview */}
           <div className="border border-white/20 rounded-lg overflow-hidden bg-checkered">
-            <img 
-              src={canvasDataUrl} 
-              alt="Canvas preview" 
+            <img
+              src={previewUrl}
+              alt={selectedLayer ? `${selectedLayer.name} preview` : 'Canvas preview'}
               className="w-full h-48 object-contain"
             />
           </div>

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -9,13 +9,28 @@ interface ExportModalProps {
   defaultFilename?: string
 }
 
-export function ExportModal({ 
-  isOpen, 
-  onClose, 
+export function buildExportFilename(sessionName?: string | null): string {
+  const now = new Date()
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const date = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+  const slug = sessionName
+    ?.toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60)
+  return slug
+    ? `${slug}-${date}`
+    : `wepaintai-${date}-${pad(now.getHours())}${pad(now.getMinutes())}`
+}
+
+export function ExportModal({
+  isOpen,
+  onClose,
   canvasDataUrl,
-  defaultFilename = `wepaintai-${Date.now()}`
+  defaultFilename
 }: ExportModalProps) {
-  const [filename, setFilename] = useState(defaultFilename)
+  const [filename, setFilename] = useState(defaultFilename ?? buildExportFilename())
   const [format, setFormat] = useState<'png' | 'jpeg'>('png')
   const [quality, setQuality] = useState(0.9)
   const [processedImageUrl, setProcessedImageUrl] = useState<string>('')
@@ -24,40 +39,46 @@ export function ExportModal({
   const isIOSDevice = isIOS()
 
   useEffect(() => {
+    if (isOpen) {
+      setFilename(defaultFilename ?? buildExportFilename())
+    }
+  }, [isOpen, defaultFilename])
+
+  useEffect(() => {
     if (!isOpen) return
 
-    const processImage = async () => {
-      setIsProcessing(true)
-      
-      if (format === 'png' || quality === 1) {
-        // For PNG or max quality JPEG, use the original data URL
-        setProcessedImageUrl(canvasDataUrl)
-      } else {
-        // For JPEG with custom quality, we need to re-encode
-        const img = new Image()
-        img.onload = () => {
-          const canvas = document.createElement('canvas')
-          canvas.width = img.width
-          canvas.height = img.height
-          const ctx = canvas.getContext('2d')
-          
-          if (ctx) {
-            // Fill with white background for JPEG (no transparency)
-            ctx.fillStyle = 'white'
-            ctx.fillRect(0, 0, canvas.width, canvas.height)
-            ctx.drawImage(img, 0, 0)
-            
-            const jpegUrl = canvas.toDataURL('image/jpeg', quality)
-            setProcessedImageUrl(jpegUrl)
-          }
-        }
-        img.src = canvasDataUrl
-      }
-      
-      setIsProcessing(false)
-    }
+    setIsProcessing(true)
 
-    processImage()
+    if (format === 'png' || quality === 1) {
+      // For PNG or max quality JPEG, use the original data URL
+      setProcessedImageUrl(canvasDataUrl)
+      setIsProcessing(false)
+    } else {
+      // For JPEG with custom quality, we need to re-encode
+      const img = new Image()
+      img.onload = () => {
+        const canvas = document.createElement('canvas')
+        canvas.width = img.width
+        canvas.height = img.height
+        const ctx = canvas.getContext('2d')
+
+        if (ctx) {
+          // Fill with white background for JPEG (no transparency)
+          ctx.fillStyle = 'white'
+          ctx.fillRect(0, 0, canvas.width, canvas.height)
+          ctx.drawImage(img, 0, 0)
+          setProcessedImageUrl(canvas.toDataURL('image/jpeg', quality))
+        } else {
+          setProcessedImageUrl(canvasDataUrl)
+        }
+        setIsProcessing(false)
+      }
+      img.onerror = () => {
+        setProcessedImageUrl(canvasDataUrl)
+        setIsProcessing(false)
+      }
+      img.src = canvasDataUrl
+    }
   }, [isOpen, canvasDataUrl, format, quality])
 
   useEffect(() => {

--- a/src/components/ImageUploadModal.tsx
+++ b/src/components/ImageUploadModal.tsx
@@ -64,7 +64,8 @@ export function ImageUploadModal({
     setIsDragging(false)
     
     const file = e.dataTransfer.files[0]
-    if (file && file.type.startsWith('image/')) {
+    if (file) {
+      // handleFileSelect validates against the shared ACCEPTED_TYPES allowlist
       handleFileSelect(file)
     }
   }, [handleFileSelect])
@@ -169,6 +170,9 @@ export function ImageUploadModal({
             </p>
             <p className="text-xs text-center text-white/60 mt-2">
               PNG, JPG, GIF, WebP • Max 5MB
+            </p>
+            <p className="text-xs text-center text-white/40 mt-1">
+              Images larger than 4096px are automatically resized
             </p>
           </div>
         ) : (

--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -13,7 +13,7 @@ import { ImageUploadModal } from './ImageUploadModal'
 import { AIGenerationModal } from './AIGenerationModal'
 import { BackgroundRemovalModal } from './BackgroundRemovalModal'
 import { MergeTwoModal } from './MergeTwoModal'
-import { ExportModal } from './ExportModal'
+import { ExportModal, buildExportFilename } from './ExportModal'
 import { UserProfile } from './UserProfile'
 import { TokenDisplay } from './TokenDisplay'
 import { usePaintingSession } from '../hooks/usePaintingSession'
@@ -613,7 +613,7 @@ export function PaintingView() {
       } else {
         // Non-iOS devices: use direct download
         const link = document.createElement('a')
-        link.download = `wepaintai-${Date.now()}.png`
+        link.download = `${buildExportFilename(session?.name)}.png`
         link.href = capture.dataUrl
         link.click()
       }
@@ -1316,7 +1316,7 @@ export function PaintingView() {
         isOpen={showExportModal}
         onClose={() => setShowExportModal(false)}
         canvasDataUrl={exportCanvasDataUrl}
-        defaultFilename={`wepaintai-${Date.now()}`}
+        defaultFilename={buildExportFilename(session?.name)}
       />
     </div>
       </ClipboardProvider>

--- a/src/components/TokenDisplay.tsx
+++ b/src/components/TokenDisplay.tsx
@@ -61,19 +61,19 @@ export function TokenDisplay({ className = '' }: TokenDisplayProps) {
       </div>
 
       {showPurchaseModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
-            <h2 className="text-xl font-bold mb-4">Purchase Tokens</h2>
+        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50">
+          <div className="bg-black/90 backdrop-blur-md border border-white/20 rounded-lg shadow-lg p-6 max-w-md w-full mx-4">
+            <h2 className="text-xl font-semibold text-white mb-4">Purchase Tokens</h2>
 
             <div className="space-y-4">
-              <div className="bg-gray-50 p-4 rounded-lg">
+              <div className="bg-white/5 border border-white/10 p-4 rounded-lg">
                 <div className="flex justify-between items-center mb-2">
-                  <span className="font-medium">Current Balance</span>
-                  <span className="text-lg font-bold text-gray-700">
+                  <span className="font-medium text-white/90">Current Balance</span>
+                  <span className="text-lg font-bold text-white">
                     {tokenBalance.tokens} tokens
                   </span>
                 </div>
-                <div className="text-sm text-gray-600">
+                <div className="text-sm text-white/60">
                   Lifetime used: {tokenBalance.lifetimeUsed} tokens
                 </div>
               </div>
@@ -85,23 +85,30 @@ export function TokenDisplay({ className = '' }: TokenDisplayProps) {
                     onClick={() => setSelectedPackageKey(tokenPackage.id)}
                     className={`w-full border-2 rounded-lg p-4 transition-all ${
                       selectedPackageKey === tokenPackage.id
-                        ? 'border-blue-500 bg-blue-50'
-                        : 'border-gray-300 bg-white hover:border-gray-400'
+                        ? 'border-blue-500 bg-blue-500/20'
+                        : 'border-white/20 bg-white/5 hover:border-white/40'
                     }`}
                   >
                     <div className="flex justify-between items-center">
                       <div className="text-left">
-                        <h3 className="font-semibold">{tokenPackage.name}</h3>
+                        <h3 className="font-semibold text-white">{tokenPackage.name}</h3>
                         {tokenPackage.id === '125_tokens' && (
-                          <p className="text-sm text-green-600 font-medium">Best Value</p>
+                          <p className="text-sm text-green-400 font-medium">Best Value</p>
                         )}
                       </div>
                       <div className="text-right">
-                        <div className="text-2xl font-bold text-blue-600">
+                        <div className="text-2xl font-bold text-blue-400">
                           {new Intl.NumberFormat(undefined, {
                             style: 'currency',
                             currency: tokenPackage.currency,
                           }).format(tokenPackage.price / 100)}
+                        </div>
+                        <div className="text-xs text-white/60">
+                          {new Intl.NumberFormat(undefined, {
+                            style: 'currency',
+                            currency: tokenPackage.currency,
+                          }).format(tokenPackage.pricePerToken)}{' '}
+                          per token
                         </div>
                       </div>
                     </div>
@@ -109,7 +116,7 @@ export function TokenDisplay({ className = '' }: TokenDisplayProps) {
                 ))}
                 {!tokenPackages && (
                   <div className="flex justify-center py-6">
-                    <Loader2 className="w-5 h-5 animate-spin text-blue-500" />
+                    <Loader2 className="w-5 h-5 animate-spin text-blue-400" />
                   </div>
                 )}
               </div>
@@ -117,14 +124,14 @@ export function TokenDisplay({ className = '' }: TokenDisplayProps) {
               <div className="flex gap-3">
                 <button
                   onClick={() => setShowPurchaseModal(false)}
-                  className="flex-1 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50"
+                  className="flex-1 px-4 py-2 border border-white/20 text-white/70 hover:text-white hover:border-white/30 rounded-lg transition-colors"
                 >
                   Cancel
                 </button>
                 <button
                   onClick={handlePurchase}
                   disabled={purchasing || !tokenPackages}
-                  className="flex-1 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                  className="flex-1 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-colors"
                 >
                   {purchasing ? (
                     <>

--- a/src/utils/imageUpload.ts
+++ b/src/utils/imageUpload.ts
@@ -1,6 +1,7 @@
 import { Id } from '../../convex/_generated/dataModel'
 
 export const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+export const MAX_IMAGE_DIMENSION = 4096 // Longest edge; larger images are downscaled client-side
 export const ACCEPTED_TYPES = ['image/png', 'image/jpeg', 'image/jpg', 'image/gif', 'image/webp']
 
 export interface ImageUploadOptions {
@@ -121,6 +122,57 @@ export function resizeImageToFitCanvas(
   })
 }
 
+export function downscaleImage(
+  file: File,
+  maxDimension: number = MAX_IMAGE_DIMENSION
+): Promise<{ blob: Blob; width: number; height: number; mimeType: string }> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    const url = URL.createObjectURL(file)
+
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+
+      const scale = maxDimension / Math.max(img.width, img.height)
+      const newWidth = Math.floor(img.width * scale)
+      const newHeight = Math.floor(img.height * scale)
+
+      const canvas = document.createElement('canvas')
+      canvas.width = newWidth
+      canvas.height = newHeight
+
+      const ctx = canvas.getContext('2d')
+      if (!ctx) {
+        reject(new Error('Failed to get canvas context'))
+        return
+      }
+
+      ctx.drawImage(img, 0, 0, newWidth, newHeight)
+
+      // Canvas can't re-encode GIFs; fall back to PNG for anything it can't produce
+      const outputType = file.type === 'image/gif' ? 'image/png' : file.type
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            resolve({ blob, width: newWidth, height: newHeight, mimeType: blob.type || outputType })
+          } else {
+            reject(new Error('Failed to create blob'))
+          }
+        },
+        outputType,
+        0.9 // Quality for JPEG/WebP
+      )
+    }
+
+    img.onerror = () => {
+      URL.revokeObjectURL(url)
+      reject(new Error('Failed to load image for resizing'))
+    }
+
+    img.src = url
+  })
+}
+
 export async function uploadImageFile(
   file: File,
   options: ImageUploadOptions,
@@ -141,18 +193,26 @@ export async function uploadImageFile(
 
     // Get image dimensions
     const originalDimensions = await getImageDimensions(file)
-    
-    // Preserve original resolution: always upload the original file and record its natural dimensions
-    const fileToUpload: File | Blob = file
-    const finalDimensions = originalDimensions
-    
+
+    // Preserve original resolution up to MAX_IMAGE_DIMENSION; downscale anything larger
+    // so huge images don't flood the canvas/AI pipeline at full resolution
+    let fileToUpload: File | Blob = file
+    let finalDimensions = originalDimensions
+    let mimeType = file.type
+    if (Math.max(originalDimensions.width, originalDimensions.height) > MAX_IMAGE_DIMENSION) {
+      const resized = await downscaleImage(file)
+      fileToUpload = resized.blob
+      finalDimensions = { width: resized.width, height: resized.height }
+      mimeType = resized.mimeType
+    }
+
     // Generate upload URL
     const uploadUrl = await generateUploadUrl({ sessionId, guestKey })
-    
+
     // Upload to Convex storage
     const response = await fetch(uploadUrl, {
       method: 'POST',
-      headers: { 'Content-Type': file.type },
+      headers: { 'Content-Type': mimeType },
       body: fileToUpload,
     })
 
@@ -171,7 +231,7 @@ export async function uploadImageFile(
       sessionId,
       storageId,
       filename: file.name,
-      mimeType: file.type,
+      mimeType,
       width: finalDimensions.width,
       height: finalDimensions.height,
       x,


### PR DESCRIPTION
## What changed

Remaining polish cluster from the UX audit (item A6 + export race):

1. **Export filename**: uses the session name + readable date (e.g. `collaborative-painting-2026-07-10.png`) instead of `wepaintai-<epoch>`, with a `wepaintai-YYYY-MM-DD-HHmm` fallback. Applied to both the iOS export modal and the desktop direct-download path (the latter had the same epoch name but wasn't in the audit item).
2. **JPEG re-encode race** in `ExportModal`: `setIsProcessing(false)` used to run synchronously while the re-encode happened later in `img.onload`, so a fast Download click could grab a stale/empty data URL. Processing state now clears inside `onload`/`onerror` (with a fallback to the original PNG on error).
3. **Background-removal preview** now shows the selected layer's image; previously it always rendered the full canvas even with a layer radio selected.
4. **Upload dimension cap**: images larger than 4096px on the longest edge are downscaled client-side in `uploadImageFile` (covers the upload modal, canvas drag-drop, and paste paths). GIFs re-encode to PNG since canvas can't emit GIF. The upload modal notes this.
5. **Drag-drop validation** in `ImageUploadModal` now goes through `validateImageFile`'s shared allowlist (and surfaces the error) instead of a separate silent `image/*` check.
6. **Flames button** in `AIGenerationModal` is labeled ("Add 'with flames' 🔥" + tooltip) instead of the unexplained "Add 🔥".
7. **Token purchase modal** restyled from a white card to the app's dark glass theme, and both packs show per-token value (from the existing server-side `pricePerToken`).

Also includes a regenerated `convex/_generated/api.d.ts` (codegen was stale; picks up the existing `sessionAuth` module).

## Verification

- `pnpm typecheck` passes (app + convex).
- Verified in local dev against a local Convex backend:
  - Export download named `collaborative-painting-2026-07-10.png` (hooked the anchor click).
  - A synthetic 6000×3000 PNG uploaded as 4096×2048.
  - Background-removal preview switches to the selected layer's storage image (alt "Upload 1 preview").
  - Flames button label/tooltip and the restyled purchase modal (per-token prices $0.10 / $0.08) render correctly.
- The iOS-only export modal path is covered by typecheck + code inspection (the Download button is hidden while `isProcessing`, which now only clears when the re-encode finishes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)