### PR TITLE
a11y: minor visual accessibility sweep (contrast, labels, hit targets, hover-only controls)

### DIFF
--- a/src/components/AIGenerationModal.tsx
+++ b/src/components/AIGenerationModal.tsx
@@ -164,7 +164,7 @@ export function AIGenerationModal({
             <div className="relative w-full h-24 sm:h-32 bg-white/10 rounded border border-white/20 overflow-hidden">
               {canvasDataUrl ? (
                 canvasDataUrl === 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=' ? (
-                  <div className="w-full h-full flex items-center justify-center text-white/40">
+                  <div className="w-full h-full flex items-center justify-center text-white/70">
                     <p className="text-sm">Empty canvas - add some content first</p>
                   </div>
                 ) : (
@@ -175,7 +175,7 @@ export function AIGenerationModal({
                   />
                 )
               ) : (
-                <div className="w-full h-full flex items-center justify-center text-white/40">
+                <div className="w-full h-full flex items-center justify-center text-white/70">
                   <p className="text-sm">Loading canvas...</p>
                 </div>
               )}

--- a/src/components/BrushSettingsModal.tsx
+++ b/src/components/BrushSettingsModal.tsx
@@ -54,7 +54,7 @@ const SettingsSlider = ({ label, value, min, max, step, onChange, description }:
         }}
       />
       {description && (
-        <p className="text-xs text-white/50">{description}</p>
+        <p className="text-xs text-white/70">{description}</p>
       )}
     </div>
   )

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -205,7 +205,7 @@ export function ExportModal({
               </button>
 
               {isIOSDevice && (
-                <p className="text-xs text-white/50 text-center">
+                <p className="text-xs text-white/70 text-center">
                   Tip: For best results on iOS, use the long-press method to save directly to Photos
                 </p>
               )}

--- a/src/components/GuestRecentModal.tsx
+++ b/src/components/GuestRecentModal.tsx
@@ -63,7 +63,7 @@ export function GuestRecentModal({ isOpen, onClose }: GuestRecentModalProps) {
         {/* List */}
         <div className="flex-1 overflow-y-auto p-2">
           {sessions.length === 0 ? (
-            <div className="text-center py-8 text-white/40 text-sm px-4">
+            <div className="text-center py-8 text-white/70 text-sm px-4">
               No recent paintings on this device yet. Paintings you open as a
               guest will show up here.
             </div>
@@ -78,16 +78,17 @@ export function GuestRecentModal({ isOpen, onClose }: GuestRecentModalProps) {
                     <div className="text-sm text-white/80 truncate">
                       {entry.name || 'Untitled'}
                     </div>
-                    <div className="text-xs text-white/40">
+                    <div className="text-xs text-white/70">
                       {new Date(entry.lastOpened).toLocaleString()}
                     </div>
                   </button>
                   <button
                     onClick={() => handleRemove(entry.sessionId)}
-                    className="p-1.5 mr-1 opacity-0 group-hover:opacity-100 hover:bg-white/20 rounded transition-all"
+                    className="p-3.5 mr-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 pointer-coarse:opacity-100 hover:bg-white/20 rounded transition-all"
                     title="Remove from list"
+                    aria-label={`Remove ${entry.name || 'Untitled'} from list`}
                   >
-                    <Trash2 className="w-3.5 h-3.5 text-white/60" />
+                    <Trash2 className="w-3.5 h-3.5 text-white/70" />
                   </button>
                 </li>
               ))}
@@ -96,7 +97,7 @@ export function GuestRecentModal({ isOpen, onClose }: GuestRecentModalProps) {
         </div>
 
         {/* Footer note */}
-        <div className="p-3 border-t border-white/10 text-xs text-white/40">
+        <div className="p-3 border-t border-white/10 text-xs text-white/70">
           Saved on this device only. Sign in to keep your paintings in a
           library that follows you everywhere.
         </div>

--- a/src/components/LibraryModal.tsx
+++ b/src/components/LibraryModal.tsx
@@ -139,7 +139,7 @@ export function LibraryModal({ isOpen, onClose, onCreateNew }: LibraryModalProps
           </h2>
           <button
             onClick={onClose}
-            className="p-1 hover:bg-white/20 rounded transition-colors"
+            className="p-3 -m-2 hover:bg-white/20 rounded transition-colors"
             aria-label="Close modal"
           >
             <X className="w-5 h-5 text-white/60" />
@@ -153,9 +153,10 @@ export function LibraryModal({ isOpen, onClose, onCreateNew }: LibraryModalProps
             <input
               type="text"
               placeholder="Search paintings..."
+              aria-label="Search paintings"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-white/10 border border-white/20 rounded-lg text-white placeholder-white/40 focus:outline-none focus:border-white/40 transition-colors"
+              className="w-full pl-10 pr-4 py-2 bg-white/10 border border-white/20 rounded-lg text-white placeholder-white/60 focus:outline-none focus:border-white/40 transition-colors"
             />
           </div>
           
@@ -186,13 +187,13 @@ export function LibraryModal({ isOpen, onClose, onCreateNew }: LibraryModalProps
             onClick={handleCreateNew}
             className="w-full mb-4 p-8 bg-white/5 hover:bg-white/10 border-2 border-dashed border-white/20 hover:border-white/40 rounded-lg transition-all flex flex-col items-center justify-center gap-2 group"
           >
-            <Plus className="w-8 h-8 text-white/40 group-hover:text-white/60 transition-colors" />
-            <span className="text-white/60 group-hover:text-white/80 transition-colors">Create New Canvas</span>
+            <Plus className="w-8 h-8 text-white/60 group-hover:text-white/80 transition-colors" />
+            <span className="text-white/70 group-hover:text-white/90 transition-colors">Create New Canvas</span>
           </button>
 
           {/* Sessions Grid */}
           {filteredSessions.length === 0 ? (
-            <div className="text-center py-8 text-white/40">
+            <div className="text-center py-8 text-white/70">
               {searchQuery ? 'No paintings found matching your search.' : 'No paintings yet. Create your first one!'}
             </div>
           ) : (
@@ -237,13 +238,15 @@ export function LibraryModal({ isOpen, onClose, onCreateNew }: LibraryModalProps
                         />
                         <button
                           onClick={handleSaveEdit}
-                          className="p-1 hover:bg-white/20 rounded text-green-400"
+                          className="p-3 -m-2 hover:bg-white/20 rounded text-green-400"
+                          aria-label="Save name"
                         >
                           ✓
                         </button>
                         <button
                           onClick={handleCancelEdit}
-                          className="p-1 hover:bg-white/20 rounded text-red-400"
+                          className="p-3 -m-2 hover:bg-white/20 rounded text-red-400"
+                          aria-label="Cancel rename"
                         >
                           ✗
                         </button>
@@ -253,7 +256,7 @@ export function LibraryModal({ isOpen, onClose, onCreateNew }: LibraryModalProps
                         <h3 className="font-medium text-white/80 truncate mb-1">
                           {session.name || 'Untitled'}
                         </h3>
-                        <p className="text-xs text-white/40">
+                        <p className="text-xs text-white/70">
                           {new Date(session._creationTime).toLocaleDateString()}
                         </p>
                       </>
@@ -262,30 +265,36 @@ export function LibraryModal({ isOpen, onClose, onCreateNew }: LibraryModalProps
 
                   {/* Actions */}
                   {editingSessionId !== session._id && (
-                    <div className="absolute top-2 left-2 opacity-0 group-hover:opacity-100 transition-opacity flex gap-1">
+                    <div className="absolute top-2 left-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 pointer-coarse:opacity-100 transition-opacity flex gap-1">
                       <button
                         onClick={(e) => {
                           e.stopPropagation()
                           handleStartEdit(session)
                         }}
-                        className="p-1.5 bg-black/60 backdrop-blur-sm hover:bg-black/80 rounded transition-colors"
+                        className="p-3.5 bg-black/60 backdrop-blur-sm hover:bg-black/80 rounded transition-colors"
                         title="Rename"
+                        aria-label={`Rename ${session.name || 'Untitled'}`}
                       >
-                        <Edit2 className="w-3.5 h-3.5 text-white/60" />
+                        <Edit2 className="w-3.5 h-3.5 text-white/70" />
                       </button>
                       <button
                         onClick={(e) => {
                           e.stopPropagation()
                           handleDelete(session._id)
                         }}
-                        className={`p-1.5 backdrop-blur-sm rounded transition-colors ${
+                        className={`p-3.5 backdrop-blur-sm rounded transition-colors ${
                           deletingSessionId === session._id
                             ? 'bg-red-600/80 hover:bg-red-600'
                             : 'bg-black/60 hover:bg-black/80'
                         }`}
                         title={deletingSessionId === session._id ? 'Click again to confirm' : 'Delete'}
+                        aria-label={
+                          deletingSessionId === session._id
+                            ? 'Click again to confirm delete'
+                            : `Delete ${session.name || 'Untitled'}`
+                        }
                       >
-                        <Trash2 className="w-3.5 h-3.5 text-white/60" />
+                        <Trash2 className="w-3.5 h-3.5 text-white/70" />
                       </button>
                     </div>
                   )}
@@ -297,7 +306,7 @@ export function LibraryModal({ isOpen, onClose, onCreateNew }: LibraryModalProps
 
         {/* Footer note: contributed-to sessions are looked up from recent
             activity only, so old collaborations may be missing */}
-        <div className="px-4 py-2 border-t border-white/10 text-xs text-white/40">
+        <div className="px-4 py-2 border-t border-white/10 text-xs text-white/70">
           Shows your paintings and recent collaborations. Older canvases you
           contributed to (but don't own) may not appear.
         </div>

--- a/src/components/MergeTwoModal.tsx
+++ b/src/components/MergeTwoModal.tsx
@@ -118,7 +118,7 @@ export function MergeTwoModal({
               <p className="text-sm text-white/60 mb-2">
                 You need at least 2 image layers to merge
               </p>
-              <p className="text-xs text-white/40">
+              <p className="text-xs text-white/70">
                 Upload images or generate AI images first
               </p>
             </div>

--- a/src/components/P2PStatus.tsx
+++ b/src/components/P2PStatus.tsx
@@ -24,14 +24,14 @@ export function P2PStatus({ isConnected, connectionMode, metrics, className = ''
   };
 
   return (
-    <div className={`flex items-center gap-2 text-sm ${className}`}>
+    <div className={`flex items-center gap-2 text-sm ${className}`} role="status">
       <div className="flex items-center gap-1">
-        <div className={`w-2 h-2 rounded-full ${getStatusColor()}`} />
-        <span className="text-gray-600">{getStatusText()}</span>
+        <div className={`w-2 h-2 rounded-full ${getStatusColor()}`} aria-hidden="true" />
+        <span className="text-gray-700">{getStatusText()}</span>
       </div>
-      
+
       {metrics && isConnected && (
-        <div className="flex items-center gap-3 text-xs text-gray-500">
+        <div className="flex items-center gap-3 text-xs text-gray-600">
           <span>Peers: {metrics.connectedPeers}</span>
           <span>Latency: {metrics.latency}ms</span>
           <span>Sent: {metrics.packetsSent}</span>

--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -1059,6 +1059,7 @@ export function PaintingView() {
             onClick={toggleAdminPanel} 
             className="absolute top-2 right-28 z-50 bg-black/90 backdrop-blur-md border border-white/20 hover:bg-black/80 text-white font-bold py-1 px-2 rounded text-xs"
             title="Toggle Admin Panel (Ctrl+Shift+A)"
+            aria-label={`${isAdminPanelVisible ? 'Hide' : 'Show'} admin panel (Ctrl+Shift+A)`}
           >
             {isAdminPanelVisible ? 'Hide' : 'Show'} Admin
           </button>

--- a/src/components/SessionInfo.tsx
+++ b/src/components/SessionInfo.tsx
@@ -28,9 +28,10 @@ export function SessionInfo({ sessionId, userCount, currentUser }: SessionInfoPr
   return (
     <div className="absolute top-4 left-4 bg-white rounded-lg shadow-lg p-4 max-w-sm">
       <div className="flex items-center gap-2 mb-3">
-        <div 
-          className="w-4 h-4 rounded-full" 
+        <div
+          className="w-4 h-4 rounded-full"
           style={{ backgroundColor: currentUser.color }}
+          aria-hidden="true"
         />
         <span className="font-medium text-sm">{currentUser.name}</span>
       </div>
@@ -46,14 +47,14 @@ export function SessionInfo({ sessionId, userCount, currentUser }: SessionInfoPr
         <Share2 className="w-4 h-4 text-gray-500" />
         <button
           onClick={handleCopySessionId}
-          className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 transition-colors"
+          className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 transition-colors py-2.5 -my-2.5 px-1 -mx-1"
         >
           <Copy className="w-3 h-3" />
           {copied ? 'Copied!' : 'Share session'}
         </button>
       </div>
 
-      <div className="mt-2 text-xs text-gray-500 font-mono bg-gray-50 p-2 rounded">
+      <div className="mt-2 text-xs text-gray-600 font-mono bg-gray-50 p-2 rounded">
         Session: {sessionId.slice(-8)}
       </div>
     </div>

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -49,13 +49,13 @@ export function ShareModal({ isOpen, onClose, sessionId }: ShareModalProps) {
             {session?.isPublic ? <Globe className="w-4 h-4" /> : <Lock className="w-4 h-4" />}
             Share
           </h3>
-          <button onClick={onClose} className="p-1 hover:bg-white/20 rounded">
+          <button onClick={onClose} className="p-3 -m-2 hover:bg-white/20 rounded" aria-label="Close share dialog">
             <X className="w-4 h-4 text-white/70" />
           </button>
         </div>
         <div className="p-4 space-y-4">
           <div>
-            <label className="text-xs text-white/60">Session link</label>
+            <label className="text-xs text-white/70">Session link</label>
             <div className="mt-1 flex items-center gap-2">
               <input
                 ref={linkInputRef}
@@ -88,15 +88,17 @@ export function ShareModal({ isOpen, onClose, sessionId }: ShareModalProps) {
           <div className="flex items-center justify-between">
             <div>
               <div className="text-sm text-white/80">Public access</div>
-              <div className="text-xs text-white/50">Allow anyone with the link to view and collaborate</div>
+              <div className="text-xs text-white/70">Allow anyone with the link to view and collaborate</div>
             </div>
-            <label className="inline-flex items-center gap-2 cursor-pointer">
-              <span className={`text-xs ${isPublic ? 'text-green-400' : 'text-white/60'}`}>
+            <label className="inline-flex items-center gap-2 cursor-pointer min-h-10">
+              <span className={`text-xs flex items-center gap-1 ${isPublic ? 'text-green-400' : 'text-white/70'}`}>
+                {isPublic ? <Globe className="w-3 h-3" aria-hidden="true" /> : <Lock className="w-3 h-3" aria-hidden="true" />}
                 {isPublic ? 'Public' : 'Private'}
               </span>
               <input
                 type="checkbox"
                 className="sr-only peer"
+                aria-label="Public access"
                 checked={isPublic}
                 disabled={!isOwner}
                 onChange={async (e) => {
@@ -116,7 +118,7 @@ export function ShareModal({ isOpen, onClose, sessionId }: ShareModalProps) {
           {currentUser === null && !!localGuestKey && (
             <div className="border-t border-white/10 pt-4">
               <div className="text-sm text-white/80">Keep this painting</div>
-              <div className="text-xs text-white/50 mt-1 mb-3">
+              <div className="text-xs text-white/70 mt-1 mb-3">
                 Right now it's only saved on this device. Sign in to keep it on
                 all your devices.
               </div>

--- a/src/components/TokenDisplay.tsx
+++ b/src/components/TokenDisplay.tsx
@@ -53,7 +53,7 @@ export function TokenDisplay({ className = '' }: TokenDisplayProps) {
         <span className="text-sm font-medium">{tokenBalance.tokens} tokens</span>
         <button
           onClick={() => setShowPurchaseModal(true)}
-          className="text-xs text-blue-500 hover:text-blue-600 underline"
+          className="text-xs text-blue-600 hover:text-blue-700 underline py-2.5 -my-2.5 px-1 -mx-1"
           data-token-buy-more
         >
           Buy more

--- a/src/components/ToolPanel.tsx
+++ b/src/components/ToolPanel.tsx
@@ -522,7 +522,7 @@ const LayerItem = React.memo(({
             <EyeOff className="w-3.5 h-3.5 text-white/40" />
           )}
         </button>
-        <span className={`flex-1 text-xs truncate ${layer.name.includes('(empty)') ? 'text-white/40' : 'text-white/80'}`}>
+        <span className={`flex-1 text-xs truncate ${layer.name.includes('(empty)') ? 'text-white/60' : 'text-white/80'}`}>
           {layer.name}
           {isActive && <span className="ml-1 text-blue-400">(Active)</span>}
         </span>
@@ -1223,7 +1223,7 @@ export function ToolPanel({
             >
               <MoreVertical className="w-3.5 h-3.5 text-white/60" />
             </button>
-            <span className="text-[10px] font-medium text-white/50 uppercase tracking-wider">Beta</span>
+            <span className="text-[10px] font-medium text-white/70 uppercase tracking-wider">Beta</span>
           </div>
           <button
             onClick={(e) => {


### PR DESCRIPTION
## What changed

Visual accessibility fixes across `src/components` from the UX audit (items X2 + X3). All changes are token/padding-level — no visual redesign. Complements the separate shared-Modal-wrapper task, which covers dialog semantics/Escape/focus.

- **Low-contrast text**: lifted secondary text at `text-white/40`/`50` to `text-white/70` (LibraryModal dates/footer/empty states, ShareModal descriptions, GuestRecentModal, AIGenerationModal, MergeTwoModal, BrushSettingsModal, ExportModal, ToolPanel "Beta" badge). White/70 on the `bg-black/90` surfaces is ~9:1, past WCAG AA 4.5:1 even with a white canvas bleeding through the overlay. Also `text-blue-500` → `text-blue-600` for TokenDisplay's "Buy more" (3.7:1 on white failed AA) and one-step gray bumps in SessionInfo/P2PStatus. Decorative icons left dimmed.
- **Color-only state**: ShareModal's public/private toggle now pairs a Globe/Lock icon with the existing Public/Private text, and its checkbox has an accessible name. P2PStatus already conveys state via distinct text per mode, so the dot is now `aria-hidden` with `role="status"` on the wrapper.
- **Missing aria-labels**: LibraryModal rename/delete/save/cancel (labels include the painting name), GuestRecentModal remove, ShareModal close, the library search input, and the admin-panel toggle in PaintingView. ToolPanel's 27 `title=` occurrences turned out to already have matching `aria-label`s, so no sweep was needed there.
- **Tiny hit targets**: modal close and rename/save/cancel buttons use `p-3 -m-2` (40px tap area, no layout shift); LibraryModal/GuestRecentModal overlay actions use `p-3.5` (42px); SessionInfo "Share session" and TokenDisplay "Buy more" text links get `py-2.5 -my-2.5` extensions.
- **Hover-only controls**: LibraryModal row actions add `group-focus-within:opacity-100 pointer-coarse:opacity-100`; GuestRecentModal's remove button adds `focus-visible:opacity-100 pointer-coarse:opacity-100`, so they're reachable by keyboard and always visible on touch devices.

## Verification

- `pnpm typecheck` passes; ESLint on all touched files: 0 errors (pre-existing warnings only)
- Exercised in `pnpm dev` in a browser: Share modal shows the icon+text toggle state and 40×40 close target; keyboard Tab reaches the GuestRecentModal remove button (opacity 1, `:focus-visible` ring); 375px viewport pass looks intact
- Confirmed the compiled CSS emits the `@media (pointer: coarse)` rule for `pointer-coarse:opacity-100` (Tailwind v4). The preview browser couldn't emulate a coarse pointer, so the touch-reveal path is verified at the CSS level — worth a quick tap-check on a real phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)