### PR TITLE
Resilience: guest live-stroke identity, pagehide leave beacon, copy polish

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -29,6 +29,7 @@ import type * as polarPackages from "../polarPackages.js";
 import type * as polarWebhook from "../polarWebhook.js";
 import type * as presence from "../presence.js";
 import type * as previewSeed from "../previewSeed.js";
+import type * as sessionAuth from "../sessionAuth.js";
 import type * as strokes from "../strokes.js";
 import type * as tokenPolicy from "../tokenPolicy.js";
 import type * as tokens from "../tokens.js";
@@ -65,6 +66,7 @@ declare const fullApi: ApiFromModules<{
   polarWebhook: typeof polarWebhook;
   presence: typeof presence;
   previewSeed: typeof previewSeed;
+  sessionAuth: typeof sessionAuth;
   strokes: typeof strokes;
   tokenPolicy: typeof tokenPolicy;
   tokens: typeof tokens;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,5 +1,6 @@
 import { httpRouter } from "convex/server";
 import { httpAction } from "./_generated/server";
+import { internal } from "./_generated/api";
 import { handlePolarWebhook } from "./polarWebhook";
 import { authComponent, createAuth } from "./auth";
 
@@ -14,6 +15,29 @@ http.route({
   method: "GET",
   handler: httpAction(async () => {
     return new Response("OK", { status: 200 });
+  }),
+});
+
+// Best-effort presence cleanup fired via navigator.sendBeacon on pagehide.
+// sendBeacon posts as a "simple" request (text/plain), so no CORS preflight
+// is needed and the response is never read — always answer 200.
+http.route({
+  path: "/presence/leave",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    try {
+      const body = JSON.parse(await request.text());
+      if (typeof body?.sessionId === "string") {
+        await ctx.runMutation(internal.presence.beaconLeave, {
+          sessionId: body.sessionId,
+          userId: typeof body.userId === "string" ? body.userId : undefined,
+          guestId: typeof body.guestId === "string" ? body.guestId : undefined,
+        });
+      }
+    } catch {
+      // Malformed beacon payloads are ignored; this endpoint is best-effort.
+    }
+    return new Response(null, { status: 200 });
   }),
 });
 

--- a/convex/liveStrokes.ts
+++ b/convex/liveStrokes.ts
@@ -9,6 +9,7 @@ export const updateLiveStroke = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
     userId: v.optional(v.id("users")),
+    guestId: v.optional(v.string()),
     userColor: v.string(),
     userName: v.string(),
     points: v.array(v.object({
@@ -32,13 +33,29 @@ export const updateLiveStroke = mutation({
 
     const now = Date.now();
 
-    // Find existing live stroke for this user in this session
-    const existingLiveStroke = await ctx.db
-      .query("liveStrokes")
-      .withIndex("by_user_session", (q) => 
-        q.eq("userId", args.userId).eq("sessionId", args.sessionId)
-      )
-      .first();
+    // Find existing live stroke for this user in this session. Guests all have
+    // userId undefined, so they are keyed by their stable per-browser guestId.
+    const existingLiveStroke = args.userId
+      ? await ctx.db
+          .query("liveStrokes")
+          .withIndex("by_user_session", (q) =>
+            q.eq("userId", args.userId).eq("sessionId", args.sessionId)
+          )
+          .first()
+      : args.guestId
+        ? await ctx.db
+            .query("liveStrokes")
+            .withIndex("by_guest_session", (q) =>
+              q.eq("guestId", args.guestId).eq("sessionId", args.sessionId)
+            )
+            .first()
+        : await ctx.db
+            .query("liveStrokes")
+            .withIndex("by_user_session", (q) =>
+              q.eq("userId", undefined).eq("sessionId", args.sessionId)
+            )
+            .filter((q) => q.eq(q.field("guestId"), undefined))
+            .first();
 
     if (existingLiveStroke) {
       // Update existing live stroke
@@ -57,6 +74,7 @@ export const updateLiveStroke = mutation({
       await ctx.db.insert("liveStrokes", {
         sessionId: args.sessionId,
         userId: args.userId,
+        guestId: args.guestId,
         userColor: args.userColor,
         userName: args.userName,
         points: args.points,
@@ -85,6 +103,7 @@ export const getLiveStrokes = query({
     _creationTime: v.number(),
     sessionId: v.id("paintingSessions"),
     userId: v.optional(v.id("users")),
+    guestId: v.optional(v.string()),
     userColor: v.string(),
     userName: v.string(),
     points: v.array(v.object({
@@ -132,6 +151,7 @@ export const clearLiveStroke = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
     userId: v.optional(v.id("users")),
+    guestId: v.optional(v.string()),
     guestKey: v.optional(v.string()),
   },
   returns: v.null(),
@@ -159,12 +179,27 @@ export const clearLiveStroke = mutation({
       }
     }
 
-    const liveStroke = await ctx.db
-      .query("liveStrokes")
-      .withIndex("by_user_session", (q) => 
-        q.eq("userId", args.userId).eq("sessionId", args.sessionId)
-      )
-      .first();
+    const liveStroke = args.userId
+      ? await ctx.db
+          .query("liveStrokes")
+          .withIndex("by_user_session", (q) =>
+            q.eq("userId", args.userId).eq("sessionId", args.sessionId)
+          )
+          .first()
+      : args.guestId
+        ? await ctx.db
+            .query("liveStrokes")
+            .withIndex("by_guest_session", (q) =>
+              q.eq("guestId", args.guestId).eq("sessionId", args.sessionId)
+            )
+            .first()
+        : await ctx.db
+            .query("liveStrokes")
+            .withIndex("by_user_session", (q) =>
+              q.eq("userId", undefined).eq("sessionId", args.sessionId)
+            )
+            .filter((q) => q.eq(q.field("guestId"), undefined))
+            .first();
 
     if (liveStroke) {
       await ctx.db.delete(liveStroke._id);

--- a/convex/presence.ts
+++ b/convex/presence.ts
@@ -176,6 +176,70 @@ export const leaveSession = mutation({
 });
 
 /**
+ * Best-effort leave fired via navigator.sendBeacon on pagehide (tab close /
+ * navigation away), routed through an HTTP action. Takes raw strings because
+ * beacon payloads are untyped; invalid ids are ignored. Removes the caller's
+ * presence row and any in-progress live stroke so collaborators don't see a
+ * ghost user or a frozen partial stroke.
+ */
+export const beaconLeave = internalMutation({
+  args: {
+    sessionId: v.string(),
+    userId: v.optional(v.string()),
+    guestId: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const sessionId = ctx.db.normalizeId("paintingSessions", args.sessionId);
+    if (!sessionId) return null;
+    const userId = args.userId
+      ? ctx.db.normalizeId("users", args.userId)
+      : null;
+    if (args.userId && !userId) return null;
+
+    const presence = userId
+      ? await ctx.db
+          .query("userPresence")
+          .withIndex("by_user_session", (q) =>
+            q.eq("userId", userId).eq("sessionId", sessionId)
+          )
+          .first()
+      : args.guestId
+        ? await ctx.db
+            .query("userPresence")
+            .withIndex("by_guest_session", (q) =>
+              q.eq("guestId", args.guestId).eq("sessionId", sessionId)
+            )
+            .first()
+        : null;
+    if (presence) {
+      await ctx.db.delete(presence._id);
+    }
+
+    const liveStroke = userId
+      ? await ctx.db
+          .query("liveStrokes")
+          .withIndex("by_user_session", (q) =>
+            q.eq("userId", userId).eq("sessionId", sessionId)
+          )
+          .first()
+      : args.guestId
+        ? await ctx.db
+            .query("liveStrokes")
+            .withIndex("by_guest_session", (q) =>
+              q.eq("guestId", args.guestId).eq("sessionId", sessionId)
+            )
+            .first()
+        : null;
+    if (liveStroke) {
+      await ctx.db.delete(liveStroke._id);
+    }
+
+    return null;
+  },
+});
+
+/**
  * Clean up old presence records (internal function)
  */
 export const cleanupOldPresence = mutation({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -69,6 +69,7 @@ const schema = defineSchema({
   liveStrokes: defineTable({
     sessionId: v.id("paintingSessions"),
     userId: v.optional(v.id("users")),
+    guestId: v.optional(v.string()), // Stable per-browser id so guests don't collide on userId=undefined
     userColor: v.string(),
     userName: v.string(),
     points: v.array(v.object({
@@ -82,7 +83,8 @@ const schema = defineSchema({
     colorMode: v.optional(v.union(v.literal("solid"), v.literal("rainbow"))), // Color mode for special effects
     lastUpdated: v.number(),
   }).index("by_session", ["sessionId"])
-    .index("by_user_session", ["userId", "sessionId"]),
+    .index("by_user_session", ["userId", "sessionId"])
+    .index("by_guest_session", ["guestId", "sessionId"]),
 
   users: defineTable({
     // Better Auth user id (identity.subject)

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -75,9 +75,13 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
             </div>
           ) : (
             <div className="py-2">
-              <p className="text-white/60 text-sm text-center mb-4">
+              <p className="text-white/60 text-sm text-center mb-2">
                 Sign in with your Google account to save your work and use AI
                 features.
+              </p>
+              <p className="text-white/40 text-xs text-center mb-4">
+                New here? Signing in with Google creates your account
+                automatically.
               </p>
               <GoogleSignInButton callbackURL={typeof window !== 'undefined' ? window.location.href : '/'} />
             </div>

--- a/src/components/MergeTwoModal.tsx
+++ b/src/components/MergeTwoModal.tsx
@@ -210,7 +210,7 @@ export function MergeTwoModal({
                   </div>
                 )}
                 <p className="text-xs text-white/60 mt-1">
-                  Optional control image for guiding the merge process
+                  Optional: the merged result will follow this layer's shapes and composition — pick one when you want the output to keep a specific layout
                 </p>
               </div>
 

--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -1116,7 +1116,7 @@ export function PaintingView() {
           ) : (
             <div className="text-center">
               <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-              <p className="text-gray-600">{sessionId ? 'Loading painting session...' : 'Creating painting session...'}</p>
+              <p className="text-gray-600">{sessionId || (typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('session')) ? 'Loading session...' : 'Creating painting session...'}</p>
             </div>
           ))}
         </div>

--- a/src/hooks/usePaintingSession.ts
+++ b/src/hooks/usePaintingSession.ts
@@ -501,6 +501,7 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
       updateLiveStroke({
         sessionId,
         userId: currentUser.id || undefined,
+        guestId: currentUser.id ? undefined : getClientId(),
         userColor: currentUser.color,
         userName: currentUser.name,
         points,
@@ -534,6 +535,7 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
         updateLiveStroke({
           sessionId,
           userId: currentUser.id || undefined,
+          guestId: currentUser.id ? undefined : getClientId(),
           userColor: currentUser.color,
           userName: currentUser.name,
           points: pending.points,
@@ -549,25 +551,47 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
     }, 16); // 16ms throttle (~60 FPS)
   }, [sessionId, updateLiveStroke, currentUser, localGuestKey]);
 
-  // Clear live stroke (when finishing drawing)
+  // Clear live stroke (when finishing drawing). Guests are keyed by their
+  // stable per-browser client id instead of a user id.
   const clearLiveStrokeForUser = useCallback(async () => {
     if (!sessionId) return;
-    
-    // Only clear if user has an ID (guest users don't have live strokes)
-    if (currentUser.id) {
-      return await clearLiveStroke({
-        sessionId,
-        userId: currentUser.id,
-        guestKey: localGuestKey || undefined,
-      });
-    }
+
+    return await clearLiveStroke({
+      sessionId,
+      userId: currentUser.id || undefined,
+      guestId: currentUser.id ? undefined : getClientId(),
+      guestKey: localGuestKey || undefined,
+    });
   }, [sessionId, currentUser.id, clearLiveStroke, localGuestKey]);
 
   // Leave session on unmount and cleanup timeouts
   useEffect(() => {
     const currentSessionId = sessionId; // Capture sessionId for cleanup
     const currentViewerId = currentUser.id; // Capture viewerId for cleanup
+
+    // Tab close / navigation away never runs React cleanup reliably, and
+    // WebSocket mutations don't flush during pagehide — use sendBeacon to an
+    // HTTP action so presence and any in-progress live stroke are removed
+    // immediately instead of lingering until the staleness cutoffs.
+    const handlePageHide = () => {
+      if (!currentSessionId) return;
+      const siteUrl = import.meta.env.VITE_CONVEX_SITE_URL;
+      if (!siteUrl || typeof navigator.sendBeacon !== "function") return;
+      const payload = JSON.stringify({
+        sessionId: currentSessionId,
+        userId: currentViewerId || undefined,
+        guestId: currentViewerId ? undefined : getClientId(),
+      });
+      // text/plain keeps this a "simple" request (no CORS preflight)
+      navigator.sendBeacon(
+        `${siteUrl}/presence/leave`,
+        new Blob([payload], { type: "text/plain" })
+      );
+    };
+    window.addEventListener("pagehide", handlePageHide);
+
     return () => {
+      window.removeEventListener("pagehide", handlePageHide);
       if (currentSessionId) {
         // Guests identify by their stable client id instead of a user id
         convexLow.mutation(api.presence.leaveSession, {


### PR DESCRIPTION
## What changed

Final remaining items from the UX audit (S-resilience remainder + copy polish).

### Orphaned live strokes (guest identity)
- `liveStrokes` gains a `guestId` field and `by_guest_session` index, mirroring the presence-identity work. Guests previously all collided on `userId=undefined` — one shared row that none of them could clear (`clearLiveStrokeForUser` was gated on `currentUser.id`).
- `updateLiveStroke` / `clearLiveStroke` now key by userId or guestId, and the frontend hook passes the stable per-browser client id for guests and no longer skips clearing for them.
- No new TTL was needed: a 30s cleanup cron and a 30s staleness filter in `getLiveStrokes` already existed.

### Guest leave events (tab close)
- New `POST /presence/leave` HTTP action backed by an internal `presence.beaconLeave` mutation that deletes the caller's presence row **and** any in-progress live stroke.
- The hook fires it via `navigator.sendBeacon` on `pagehide` (text/plain, so no CORS preflight). React cleanup / WebSocket mutations don't run reliably on tab close, so users previously lingered in the online count up to 5 minutes.
- The existing unmount cleanup already handled guests via guestId (landed with the presence-identity work); this covers the tab-close path for everyone.

### Copy polish
- **PaintingView**: shows "Loading session..." when `?session=` is present in the URL (checked directly, since the `sessionId` state is null for the first few renders and briefly flashed "Creating painting session…" at joiners).
- **AuthModal**: adds the "New here? Signing in with Google creates your account automatically." reassurance that previously existed only on `/login`.
- **MergeTwoModal**: replaces the circular control-layer description with what it actually does (the merged result follows the control layer's shapes/composition — `control_image` on fofr/image-merger).

## Reviewer notes

- The Convex live-stroke path is currently dormant in the UI: KonvaCanvas destructures the API but never calls it; collaborative previews travel over P2P, which already drops a peer's strokes on disconnect. These fixes make the Convex fallback correct whenever it's used.
- The pagehide listener registers twice (both `PaintingView` and `KonvaCanvas` mount `usePaintingSession`), so two beacons fire on close; the second is a harmless no-op.
- Two tabs in one browser share a guest identity (`getClientId` is per-browser), so closing one tab removes the shared presence row until the surviving tab's 20s heartbeat restores it — same trade-off the existing unmount cleanup already had.
- `convex/_generated/api.d.ts` diff is codegen for the new function.

## Verification

- `pnpm typecheck` passes (app + convex).
- Live-tested against a local Convex backend: real `pagehide` in the app fired the beacon and the presence row was deleted server-side; curl to the endpoint deleted a guest's live stroke; two guests now hold separate live-stroke rows and each can clear its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)