### PR TITLE
Lock down public unauthenticated Convex mutations

### DIFF
--- a/convex/aiGeneration.ts
+++ b/convex/aiGeneration.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
-import { mutation, action, query } from "./_generated/server";
-import { api, internal } from "./_generated/api";
+import { mutation, action, query, internalMutation } from "./_generated/server";
+import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 
 // Verbose logging of prompts and image-data samples is a privacy concern in
@@ -10,8 +10,11 @@ function debugLog(...args: unknown[]) {
   if (AI_GEN_DEBUG) console.log(...args);
 }
 
-// Mutation to store AI generation requests and results
-export const createGenerationRequest = mutation({
+// Mutation to store AI generation requests and results.
+// Internal-only: invoked from generation actions via ctx.runMutation. Exposing
+// this publicly would let any client inject arbitrary result URLs into a
+// session's generation feed (see getSessionGenerations).
+export const createGenerationRequest = internalMutation({
   args: {
     sessionId: v.id("paintingSessions"),
     prompt: v.string(),
@@ -38,8 +41,9 @@ export const createGenerationRequest = mutation({
   },
 });
 
-// Update generation status
-export const updateGenerationStatus = mutation({
+// Update generation status. Internal-only: patches any aiGenerations doc by id
+// with no auth, so it must never be client-callable.
+export const updateGenerationStatus = internalMutation({
   args: {
     generationId: v.id("aiGenerations"),
     status: v.union(v.literal("pending"), v.literal("processing"), v.literal("completed"), v.literal("failed")),
@@ -109,7 +113,7 @@ export const generateImage = action({
 
     try {
       // Create a generation request record
-      const generationId = await ctx.runMutation(api.aiGeneration.createGenerationRequest, {
+      const generationId = await ctx.runMutation(internal.aiGeneration.createGenerationRequest, {
         sessionId: args.sessionId,
         prompt: args.prompt,
         status: "pending",
@@ -214,7 +218,7 @@ export const generateImage = action({
       if (!response.ok) {
         const error = await response.text();
         console.error("Replicate API error:", error);
-        await ctx.runMutation(api.aiGeneration.updateGenerationStatus, {
+        await ctx.runMutation(internal.aiGeneration.updateGenerationStatus, {
           generationId,
           status: "failed",
           error: "Failed to start generation",
@@ -226,7 +230,7 @@ export const generateImage = action({
       debugLog('[AI-GEN] Created prediction:', prediction.id);
       
       // Update with Replicate ID
-      await ctx.runMutation(api.aiGeneration.updateGenerationStatus, {
+      await ctx.runMutation(internal.aiGeneration.updateGenerationStatus, {
         generationId,
         status: "processing",
         replicateId: prediction.id,
@@ -314,7 +318,7 @@ export const generateImage = action({
               debugLog('Final URL type:', typeof finalUrl);
               debugLog('Final URL length:', finalUrl?.length);
               
-              await ctx.runMutation(api.aiGeneration.updateGenerationStatus, {
+              await ctx.runMutation(internal.aiGeneration.updateGenerationStatus, {
                 generationId,
                 status: "completed",
                 resultImageUrl: finalUrl,
@@ -341,7 +345,7 @@ export const generateImage = action({
               }
               
               // Fallback to using the Replicate URL directly
-              await ctx.runMutation(api.aiGeneration.updateGenerationStatus, {
+              await ctx.runMutation(internal.aiGeneration.updateGenerationStatus, {
                 generationId,
                 status: "completed",
                 resultImageUrl: imageUrl,
@@ -363,7 +367,7 @@ export const generateImage = action({
             }
           }
         } else if (status.status === "failed" || status.status === "canceled") {
-          await ctx.runMutation(api.aiGeneration.updateGenerationStatus, {
+          await ctx.runMutation(internal.aiGeneration.updateGenerationStatus, {
             generationId,
             status: "failed",
             error: status.error || "Generation failed",
@@ -377,7 +381,7 @@ export const generateImage = action({
       }
 
       // Timeout
-      await ctx.runMutation(api.aiGeneration.updateGenerationStatus, {
+      await ctx.runMutation(internal.aiGeneration.updateGenerationStatus, {
         generationId,
         status: "failed",
         error: "Generation timed out",

--- a/convex/geminiGeneration.ts
+++ b/convex/geminiGeneration.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { action } from "./_generated/server";
-import { api, internal } from "./_generated/api";
+import { internal } from "./_generated/api";
 
 // Generate an image using Gemini 2.5 Flash Image (preview)
 export const generateImage = action({
@@ -36,7 +36,7 @@ export const generateImage = action({
     }
 
     // Create a generation request record
-    const generationId = await ctx.runMutation(api.aiGeneration.createGenerationRequest, {
+    const generationId = await ctx.runMutation(internal.aiGeneration.createGenerationRequest, {
       sessionId: args.sessionId,
       prompt: args.prompt,
       status: "pending",
@@ -80,7 +80,7 @@ export const generateImage = action({
       if (!response.ok) {
         const errorText = await response.text();
         console.error('[GEMINI] API error:', errorText);
-        await ctx.runMutation(api.aiGeneration.updateGenerationStatus, {
+        await ctx.runMutation(internal.aiGeneration.updateGenerationStatus, {
           generationId,
           status: 'failed',
           error: 'Failed to start generation',
@@ -106,7 +106,7 @@ export const generateImage = action({
 
       if (!imageBase64) {
         console.error('[GEMINI] No image data in response');
-        await ctx.runMutation(api.aiGeneration.updateGenerationStatus, {
+        await ctx.runMutation(internal.aiGeneration.updateGenerationStatus, {
           generationId,
           status: 'failed',
           error: 'No image data returned from Gemini',
@@ -124,7 +124,7 @@ export const generateImage = action({
       const storageId = await ctx.storage.store(blob);
       const storageUrl = await ctx.storage.getUrl(storageId);
 
-      await ctx.runMutation(api.aiGeneration.updateGenerationStatus, {
+      await ctx.runMutation(internal.aiGeneration.updateGenerationStatus, {
         generationId,
         status: 'completed',
         resultImageUrl: storageUrl || '',

--- a/convex/imageMerger.ts
+++ b/convex/imageMerger.ts
@@ -1,10 +1,11 @@
 import { v } from "convex/values";
-import { mutation, action, query } from "./_generated/server";
+import { mutation, action, query, internalMutation } from "./_generated/server";
 import { api, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 
-// Mutation to store image merge requests and results
-export const createMergeRequest = mutation({
+// Mutation to store image merge requests and results.
+// Internal-only: invoked from the mergeImages action via ctx.runMutation.
+export const createMergeRequest = internalMutation({
   args: {
     sessionId: v.id("paintingSessions"),
     firstLayerId: v.string(),
@@ -35,8 +36,9 @@ export const createMergeRequest = mutation({
   },
 });
 
-// Update merge status
-export const updateMergeStatus = mutation({
+// Update merge status. Internal-only: patches any imageMerges doc by id with no
+// auth, so it must never be client-callable.
+export const updateMergeStatus = internalMutation({
   args: {
     mergeId: v.id("imageMerges"),
     status: v.union(v.literal("pending"), v.literal("processing"), v.literal("completed"), v.literal("failed")),
@@ -133,7 +135,7 @@ export const mergeImages = action({
 
     try {
       // Create a merge request record
-      const mergeId = await ctx.runMutation(api.imageMerger.createMergeRequest, {
+      const mergeId = await ctx.runMutation(internal.imageMerger.createMergeRequest, {
         sessionId: args.sessionId,
         firstLayerId: args.firstLayerId,
         secondLayerId: args.secondLayerId,
@@ -190,7 +192,7 @@ export const mergeImages = action({
         });
       } catch (error) {
         console.error('[IMAGE-MERGE] Failed to get layer image URLs:', error);
-        await ctx.runMutation(api.imageMerger.updateMergeStatus, {
+        await ctx.runMutation(internal.imageMerger.updateMergeStatus, {
           mergeId,
           status: "failed",
           error: "Failed to get layer images",
@@ -238,7 +240,7 @@ export const mergeImages = action({
       if (!response.ok) {
         const error = await response.text();
         console.error("Replicate API error:", error);
-        await ctx.runMutation(api.imageMerger.updateMergeStatus, {
+        await ctx.runMutation(internal.imageMerger.updateMergeStatus, {
           mergeId,
           status: "failed",
           error: "Failed to start merge",
@@ -250,7 +252,7 @@ export const mergeImages = action({
       console.log('[IMAGE-MERGE] Created prediction:', prediction);
       
       // Update with Replicate ID
-      await ctx.runMutation(api.imageMerger.updateMergeStatus, {
+      await ctx.runMutation(internal.imageMerger.updateMergeStatus, {
         mergeId,
         status: "processing",
         replicateId: prediction.id,
@@ -335,7 +337,7 @@ export const mergeImages = action({
               const finalUrl = storageUrl || imageUrl;
               console.log('[IMAGE-MERGE] Final URL to return:', finalUrl);
               
-              await ctx.runMutation(api.imageMerger.updateMergeStatus, {
+              await ctx.runMutation(internal.imageMerger.updateMergeStatus, {
                 mergeId,
                 status: "completed",
                 resultImageUrl: finalUrl,
@@ -361,7 +363,7 @@ export const mergeImages = action({
               }
               
               // Fallback to using the Replicate URL directly
-              await ctx.runMutation(api.imageMerger.updateMergeStatus, {
+              await ctx.runMutation(internal.imageMerger.updateMergeStatus, {
                 mergeId,
                 status: "completed",
                 resultImageUrl: imageUrl,
@@ -380,7 +382,7 @@ export const mergeImages = action({
             }
           }
         } else if (status.status === "failed" || status.status === "canceled") {
-          await ctx.runMutation(api.imageMerger.updateMergeStatus, {
+          await ctx.runMutation(internal.imageMerger.updateMergeStatus, {
             mergeId,
             status: "failed",
             error: status.error || "Merge failed",
@@ -394,7 +396,7 @@ export const mergeImages = action({
       }
 
       // Timeout
-      await ctx.runMutation(api.imageMerger.updateMergeStatus, {
+      await ctx.runMutation(internal.imageMerger.updateMergeStatus, {
         mergeId,
         status: "failed",
         error: "Merge timed out",

--- a/convex/paintingSessions.ts
+++ b/convex/paintingSessions.ts
@@ -444,12 +444,15 @@ export const addAIPrompt = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
     prompt: v.string(),
+    guestKey: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const session = await ctx.db.get(args.sessionId);
     if (!session) {
       throw new Error("Session not found");
     }
+
+    await assertCanModifySession(ctx, session, args.guestKey);
 
     const currentPrompts = session.aiPrompts || [];
     

--- a/convex/presence.ts
+++ b/convex/presence.ts
@@ -240,9 +240,10 @@ export const beaconLeave = internalMutation({
 });
 
 /**
- * Clean up old presence records (internal function)
+ * Clean up old presence records (internal function).
+ * Internal-only duplicate of the cron-driven cleanup; never client-callable.
  */
-export const cleanupOldPresence = mutation({
+export const cleanupOldPresence = internalMutation({
   args: {},
   returns: v.null(),
   handler: async (ctx) => {

--- a/convex/viewerAcks.ts
+++ b/convex/viewerAcks.ts
@@ -1,6 +1,7 @@
-import { mutation, query } from "./_generated/server";
+import { mutation, query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 import { Id } from "./_generated/dataModel";
+import { assertCanModifySession } from "./sessionAuth";
 
 /**
  * Upsert (update or insert) the acknowledged stroke order for a viewer in a session.
@@ -10,9 +11,16 @@ export const upsertViewerState = mutation({
     sessionId: v.id("paintingSessions"),
     viewerId: v.string(), // Client-generated viewer ID
     lastAckedStrokeOrder: v.number(),
+    guestKey: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
+    const session = await ctx.db.get(args.sessionId);
+    if (!session) {
+      throw new Error("Session not found");
+    }
+    await assertCanModifySession(ctx, session, args.guestKey);
+
     const existingState = await ctx.db
       .query("viewerStates")
       .withIndex("by_session_viewer", (q) =>
@@ -98,9 +106,16 @@ export const removeViewerState = mutation({
   args: {
     sessionId: v.id("paintingSessions"),
     viewerId: v.string(),
+    guestKey: v.optional(v.string()),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
+    const session = await ctx.db.get(args.sessionId);
+    if (!session) {
+      throw new Error("Session not found");
+    }
+    await assertCanModifySession(ctx, session, args.guestKey);
+
     const existingState = await ctx.db
       .query("viewerStates")
       .withIndex("by_session_viewer", (q) =>
@@ -116,9 +131,11 @@ export const removeViewerState = mutation({
 });
 
 /**
- * Clear all viewer states for a session (useful when clearing the canvas)
+ * Clear all viewer states for a session (useful when clearing the canvas).
+ * Internal-only: no client callers, and it would otherwise let anyone wipe a
+ * session's viewer sync state.
  */
-export const clearSessionViewerStates = mutation({
+export const clearSessionViewerStates = internalMutation({
   args: {
     sessionId: v.id("paintingSessions"),
   },

--- a/src/components/AIGenerationModal.tsx
+++ b/src/components/AIGenerationModal.tsx
@@ -84,7 +84,7 @@ export function AIGenerationModal({
       if (result.success && 'imageUrl' in result && result.imageUrl) {
         console.log('Generated image URL:', result.imageUrl)
         // Save the prompt to both session and user history
-        await addAIPrompt({ sessionId, prompt: prompt.trim() })
+        await addAIPrompt({ sessionId, prompt: prompt.trim(), guestKey: getGuestKey(sessionId) || undefined })
         await addUserPrompt({ prompt: prompt.trim() })
         onGenerationComplete(result.imageUrl)
         onClose()

--- a/src/hooks/usePaintingSession.ts
+++ b/src/hooks/usePaintingSession.ts
@@ -238,10 +238,11 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
           sessionId,
           viewerId: currentUser.id,
           lastAckedStrokeOrder: maxStrokeOrder,
+          guestKey: localGuestKey || undefined,
         });
       }
     }
-  }, [strokes, sessionId, currentUser.id, upsertViewerState]);
+  }, [strokes, sessionId, currentUser.id, upsertViewerState, localGuestKey]);
 
   // Create a new session
   const createNewSession = useCallback(async (
@@ -437,6 +438,7 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
         sessionId,
         viewerId: currentUser.id,
         lastAckedStrokeOrder: 0,
+        guestKey: localGuestKey || undefined,
       });
     }
   }, [sessionId, clearSessionMutation, clearSessionLiveStrokes, currentUser.id, upsertViewerState, localGuestKey]);
@@ -604,7 +606,11 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
           guestId: currentViewerId ? undefined : getClientId(),
         });
         if (currentViewerId) {
-          removeViewerState({ sessionId: currentSessionId, viewerId: currentViewerId });
+          removeViewerState({
+            sessionId: currentSessionId,
+            viewerId: currentViewerId,
+            guestKey: getGuestKey(currentSessionId) || undefined,
+          });
         }
       }
       // Clean up any pending live stroke updates


### PR DESCRIPTION
## What

Security follow-up from the post-merge review of the UX-audit authorization cluster (#64/#66/#67/#71): several Convex mutations were still public and unauthenticated, callable by any client against any session.

### HIGH — AI-generation / merge feed injection
`aiGeneration.createGenerationRequest` / `updateGenerationStatus` and `imageMerger.createMergeRequest` / `updateMergeStatus` are now `internalMutation`s, invoked via `internal.*` from their actions (including `geminiGeneration.ts`, which also called the aiGeneration pair). Previously an attacker could insert a `"completed"` generation with an arbitrary `resultImageUrl` into a victim session — `getSessionGenerations` would then serve that URL into the victim's recent-generations UI — or patch any generation/merge doc by id. These four were only ever called server-side via `ctx.runMutation`; no client callers existed (re-verified by grep).

### MEDIUM — unauthorized prompt write
`paintingSessions.addAIPrompt` now requires `assertCanModifySession`, with `guestKey` threaded from the `AIGenerationModal` call site. Previously anyone with a session id could append arbitrary strings to a private session's prompt history (the read side was already authorized).

### LOW
- `presence.cleanupOldPresence` → `internalMutation` (public duplicate of the cron-driven internal cleanup).
- `viewerAcks.upsertViewerState` / `removeViewerState` now check `assertCanModifySession` (`guestKey` threaded through `usePaintingSession`); `clearSessionViewerStates` had no callers anywhere and is now internal.

## Verification

- `pnpm typecheck` clean, `pnpm test:run` 48/48, eslint 0 errors on touched files.
- Live probes against a local backend over the public Convex HTTP API: all six converted functions return `Could not find public function`; `addAIPrompt` / `upsertViewerState` on a private session return `Unauthorized` with a missing or wrong `guestKey` and succeed with the correct one; `getAIPrompts` returns the prompt only to the owner.
- In-app: guest painting (exercises the new viewerAcks auth) works with no console errors; `generateImage` / `mergeImages` actions deploy and run to their auth gates.

## Reviewer notes

- The full authenticated Replicate round-trip wasn't runnable locally (no OAuth / API token on the anonymous local backend); the only change on that path is the `api.*` → `internal.*` ref swap, verified by codegen + typecheck.
- Tiny behavior change: `removeViewerState` on unmount now throws "Session not found" for a deleted session instead of silently no-oping. It's a fire-and-forget call in a React cleanup handler, so worst case is a console warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)