### PR TITLE
Post-merge review cleanups: redirect sanitizer, OAuth cancel UX, presence count, a11y

### DIFF
--- a/convex/aiGeneration.ts
+++ b/convex/aiGeneration.ts
@@ -419,13 +419,23 @@ export const getSessionGenerations = query({
         }
       }
     }
+    // Take a larger window then filter, so a run of failed/moderated rows
+    // doesn't shrink the strip; then keep the 10 most recent usable results.
+    // Only Convex-storage URLs are usable — direct Replicate URLs (the
+    // storage-failure fallback) expire and would render as broken thumbnails.
     const generations = await ctx.db
       .query("aiGenerations")
       .withIndex("by_session", (q) => q.eq("sessionId", args.sessionId))
       .order("desc")
-      .take(10);
+      .take(50);
     return generations
-      .filter((g) => g.status === "completed" && g.resultImageUrl)
+      .filter(
+        (g) =>
+          g.status === "completed" &&
+          g.resultImageUrl &&
+          g.resultImageUrl.includes("/api/storage/")
+      )
+      .slice(0, 10)
       .map((g) => ({
         _id: g._id,
         prompt: g.prompt,

--- a/convex/paintingSessions.ts
+++ b/convex/paintingSessions.ts
@@ -327,8 +327,10 @@ export const restoreSession = mutation({
       .query("users")
       .withIndex("by_auth_id", (q) => q.eq("authId", identity.subject))
       .first();
+    // Non-owners get the same answer as a missing id so they can't probe
+    // whether a session exists (getSession deliberately hides this too)
     if (!user || session.createdBy !== user._id) {
-      throw new Error("You can only restore your own sessions");
+      return "not_found";
     }
 
     if (session.deletedAt === undefined) return "restored"; // already live

--- a/src/components/AIGenerationModal.tsx
+++ b/src/components/AIGenerationModal.tsx
@@ -114,8 +114,9 @@ export function AIGenerationModal({
         {/* Close button */}
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 text-white/70 hover:text-white transition-colors z-10 bg-black/50 rounded-full p-1"
+          className="absolute top-2.5 right-2.5 text-white/70 hover:text-white transition-colors z-10 bg-black/50 rounded-full p-2.5"
           disabled={isGenerating}
+          aria-label="Close modal"
         >
           <X className="w-5 h-5" />
         </button>
@@ -183,7 +184,7 @@ export function AIGenerationModal({
                 disabled={isGenerating}
                 className="w-full accent-blue-500"
               />
-              <div className="flex justify-between text-xs text-white/50">
+              <div className="flex justify-between text-xs text-white/70">
                 <span>Ignore canvas</span>
                 <span>Keep my drawing</span>
               </div>
@@ -359,7 +360,7 @@ export function AIGenerationModal({
                   </button>
                 ))}
               </div>
-              <p className="text-xs text-white/50 mt-1">Click a thumbnail to add it back as a layer.</p>
+              <p className="text-xs text-white/70 mt-1">Click a thumbnail to add it back as a layer.</p>
             </div>
           )}
 

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -79,7 +79,7 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
                 Sign in with your Google account to save your work and use AI
                 features.
               </p>
-              <p className="text-white/40 text-xs text-center mb-4">
+              <p className="text-white/70 text-xs text-center mb-4">
                 New here? Signing in with Google creates your account
                 automatically.
               </p>

--- a/src/components/BackgroundRemovalModal.tsx
+++ b/src/components/BackgroundRemovalModal.tsx
@@ -123,7 +123,8 @@ export function BackgroundRemovalModal({
         {/* Close button */}
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 text-white/70 hover:text-white transition-colors z-10 bg-black/50 rounded-full p-1"
+          className="absolute top-2.5 right-2.5 text-white/70 hover:text-white transition-colors z-10 bg-black/50 rounded-full p-2.5"
+          aria-label="Close modal"
         >
           <X className="w-5 h-5" />
         </button>

--- a/src/components/ImageUploadModal.tsx
+++ b/src/components/ImageUploadModal.tsx
@@ -171,7 +171,7 @@ export function ImageUploadModal({
             <p className="text-xs text-center text-white/60 mt-2">
               PNG, JPG, GIF, WebP • Max 5MB
             </p>
-            <p className="text-xs text-center text-white/40 mt-1">
+            <p className="text-xs text-center text-white/70 mt-1">
               Images larger than 4096px are automatically resized
             </p>
           </div>

--- a/src/components/LibraryModal.tsx
+++ b/src/components/LibraryModal.tsx
@@ -236,7 +236,7 @@ export function LibraryModal({ isOpen, onClose, onCreateNew, onOpenSession }: Li
                   {/* Info */}
                   <div className="p-3">
                     {editingSessionId === session._id ? (
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-3">
                         <input
                           type="text"
                           value={editingName}
@@ -250,14 +250,14 @@ export function LibraryModal({ isOpen, onClose, onCreateNew, onOpenSession }: Li
                         />
                         <button
                           onClick={handleSaveEdit}
-                          className="p-3 -m-2 hover:bg-white/20 rounded text-green-400"
+                          className="p-3 -m-1.5 hover:bg-white/20 rounded text-green-400"
                           aria-label="Save name"
                         >
                           ✓
                         </button>
                         <button
                           onClick={handleCancelEdit}
-                          className="p-3 -m-2 hover:bg-white/20 rounded text-red-400"
+                          className="p-3 -m-1.5 hover:bg-white/20 rounded text-red-400"
                           aria-label="Cancel rename"
                         >
                           ✗
@@ -316,11 +316,9 @@ export function LibraryModal({ isOpen, onClose, onCreateNew, onOpenSession }: Li
           )}
         </div>
 
-        {/* Footer note: contributed-to sessions are looked up from recent
-            activity only, so old collaborations may be missing */}
+        {/* Footer note */}
         <div className="px-4 py-2 border-t border-white/10 text-xs text-white/70">
-          Shows your paintings and recent collaborations. Older canvases you
-          contributed to (but don't own) may not appear.
+          Shows paintings you own.
         </div>
 
         {/* Undo-delete toast */}

--- a/src/components/MergeTwoModal.tsx
+++ b/src/components/MergeTwoModal.tsx
@@ -100,8 +100,9 @@ export function MergeTwoModal({
         {/* Close button */}
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 text-white/70 hover:text-white transition-colors z-10 bg-black/50 rounded-full p-1"
+          className="absolute top-2.5 right-2.5 text-white/70 hover:text-white transition-colors z-10 bg-black/50 rounded-full p-2.5"
           disabled={isMerging}
+          aria-label="Close modal"
         >
           <X className="w-5 h-5" />
         </button>

--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -5,7 +5,7 @@ import { ToolPanel, Layer } from './ToolPanel'
 import { type BrushSettings } from './BrushSettingsModal'
 import { AdminPanel } from './AdminPanel' // Import AdminPanel
 import { SessionInfo } from './SessionInfo'
-import { PresenceStrip } from './PresenceStrip'
+import { PresenceStrip, activeCollaborators } from './PresenceStrip'
 import { SyncStatusBanner } from './SyncStatusBanner'
 import { P2PStatus } from './P2PStatus'
 import { P2PDebugPanel } from './P2PDebugPanel'
@@ -473,17 +473,36 @@ export function PaintingView() {
 
   // Switch to another session (or null to create a fresh one) without a full
   // page reload: update the URL via history and let React state drive the swap.
+  // Opening a concrete session pushes a history entry so Back returns to the
+  // previous canvas instead of exiting the app; the null/new-canvas case keeps
+  // replaceState (a fresh session id gets written over it once created).
   const switchToSession = useCallback((newSessionId: Id<"paintingSessions"> | null) => {
     try {
       const url = new URL(window.location.href)
       if (newSessionId) {
         url.searchParams.set('session', newSessionId)
+        window.history.pushState({}, '', url.toString())
       } else {
         url.searchParams.delete('session')
+        window.history.replaceState({}, '', url.toString())
       }
-      window.history.replaceState({}, '', url.toString())
     } catch {}
     setSessionId(newSessionId)
+  }, [])
+
+  // Follow browser Back/Forward across the entries pushed above. Entries
+  // without a session param are ambiguous (guest-owned URLs are masked), so
+  // only concrete session ids are followed.
+  useEffect(() => {
+    const onPopState = () => {
+      const params = new URLSearchParams(window.location.search)
+      const target = params.get('session') as Id<"paintingSessions"> | null
+      if (target) {
+        setSessionId((current) => (current === target ? current : target))
+      }
+    }
+    window.addEventListener('popstate', onPopState)
+    return () => window.removeEventListener('popstate', onPopState)
   }, [])
 
   // Leave the current session behind so a fresh painting is created
@@ -1110,7 +1129,10 @@ export function PaintingView() {
       )}
 
       {validSessionId ? (
+        // key forces a remount on session switch so per-session canvas state
+        // (pendingStrokes, imageMasks, konvaImages) resets by contract
         <KonvaCanvas
+          key={validSessionId}
           ref={canvasRef}
           sessionId={validSessionId}
           color={color}
@@ -1183,7 +1205,7 @@ export function PaintingView() {
       {adminFeaturesEnabled && (
         <SessionInfo
           sessionId={sessionId}
-          userCount={presence.length + 1}
+          userCount={activeCollaborators(presence, currentUser.id, presenceGuestId).length + 1}
           currentUser={currentUser}
         />
       )}

--- a/src/components/PresenceStrip.tsx
+++ b/src/components/PresenceStrip.tsx
@@ -24,15 +24,21 @@ function initialOf(name: string): string {
   return trimmed ? trimmed[0].toUpperCase() : '?'
 }
 
-export function PresenceStrip({ presence, currentUser, presenceGuestId, connectionStatus }: PresenceStripProps) {
+/**
+ * Presence rows for everyone but the current user, deduped by identity
+ * (userId, guestId, or record id as fallback) and limited to recently-active
+ * records. Shared so every online count in the UI agrees with the strip.
+ */
+export function activeCollaborators(
+  presence: UserPresence[],
+  currentUserId: Id<'users'> | null,
+  presenceGuestId?: string
+): UserPresence[] {
   const now = Date.now()
-
   const isSelf = (p: UserPresence) =>
-    currentUser.id ? p.userId === currentUser.id : !!presenceGuestId && p.guestId === presenceGuestId
-
-  // Dedupe collaborators by identity (userId, guestId, or record id as fallback)
+    currentUserId ? p.userId === currentUserId : !!presenceGuestId && p.guestId === presenceGuestId
   const seen = new Set<string>()
-  const collaborators = presence.filter((p) => {
+  return presence.filter((p) => {
     if (isSelf(p)) return false
     if (now - p.lastSeen > ACTIVE_WINDOW_MS) return false
     const key = p.userId?.toString() || p.guestId || p._id.toString()
@@ -40,6 +46,10 @@ export function PresenceStrip({ presence, currentUser, presenceGuestId, connecti
     seen.add(key)
     return true
   })
+}
+
+export function PresenceStrip({ presence, currentUser, presenceGuestId, connectionStatus }: PresenceStripProps) {
+  const collaborators = activeCollaborators(presence, currentUser.id, presenceGuestId)
 
   const onlineCount = collaborators.length + 1
   const maxDots = 5

--- a/src/components/ToolPanel.tsx
+++ b/src/components/ToolPanel.tsx
@@ -679,6 +679,28 @@ export function ToolPanel({
   const [isCollapsed, setIsCollapsed] = React.useState(false)
   const [showMenu, setShowMenu] = React.useState(false)
   const [showAuthModal, setShowAuthModal] = React.useState(false)
+
+  // Surface OAuth round-trip failures on the canvas: sign-in from the in-app
+  // modal redirects back here with an `error` query param (e.g. the user
+  // cancelled at Google), but the modal that initiated it is gone after the
+  // reload. Reopen it so GoogleSignInButton can show the error and scrub the
+  // param; if the user is actually signed in, the param is stale — just scrub.
+  React.useEffect(() => {
+    if (!isLoaded) return
+    const params = new URLSearchParams(window.location.search)
+    if (!params.get('error')) return
+    if (isSignedIn) {
+      params.delete('error')
+      const query = params.toString()
+      window.history.replaceState(
+        null,
+        '',
+        window.location.pathname + (query ? `?${query}` : '') + window.location.hash
+      )
+    } else {
+      setShowAuthModal(true)
+    }
+  }, [isLoaded, isSignedIn])
   const [showGuestRecent, setShowGuestRecent] = React.useState(false)
   const [menuPosition, setMenuPosition] = React.useState({ x: 0, y: 0 })
   const [activeTab, setActiveTab] = React.useState<TabId>('tools')

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { GoogleSignInButton } from '../components/GoogleSignInButton'
 
@@ -10,11 +11,20 @@ export const Route = createFileRoute('/login')({
 
 function LoginComponent() {
   const { redirect } = Route.useSearch()
-  // Only same-origin relative paths, so the param can't redirect off-site
-  const callbackURL =
-    redirect && redirect.startsWith('/') && !redirect.startsWith('//')
-      ? redirect
-      : '/'
+  // Only same-origin paths, so the param can't redirect off-site. Resolve the
+  // value against our origin and compare origins rather than string-matching
+  // prefixes (e.g. `/\evil.com` resolves to https://evil.com/).
+  const callbackURL = React.useMemo(() => {
+    if (!redirect || typeof window === 'undefined') return '/'
+    try {
+      const url = new URL(redirect, window.location.origin)
+      return url.origin === window.location.origin
+        ? url.pathname + url.search + url.hash
+        : '/'
+    } catch {
+      return '/'
+    }
+  }, [redirect])
   return (
     <div className="min-h-screen flex items-center justify-center bg-neutral-950 py-12 px-4 sm:px-6 lg:px-8">
       <div className="w-full max-w-md bg-black/90 backdrop-blur-md border border-white/20 rounded-lg shadow-xl p-8">
@@ -25,7 +35,7 @@ function LoginComponent() {
           Sign in with your Google account to save your work and use AI
           features.
         </p>
-        <p className="text-white/40 text-xs text-center mb-6">
+        <p className="text-white/70 text-xs text-center mb-6">
           New here? Signing in with Google creates your account automatically.
         </p>
         <GoogleSignInButton callbackURL={callbackURL} />


### PR DESCRIPTION
## What changed

Batch of 10 independent, low-risk fixes from the post-merge review of the UX audit work.

### Medium

1. **Open-redirect sanitizer bypass** ([login.tsx](../blob/claude/great-blackburn-35f195/src/routes/login.tsx)) — the old `startsWith('/') && !startsWith('//')` check let `?redirect=/\evil.com` through (it resolves to `https://evil.com/`). Now the param is resolved against `window.location.origin` and origins are compared; anything cross-origin falls back to `/`. Verified live: the malicious param resolves to `http://evil.com` and is rejected.
2. **OAuth cancel gave no feedback** (ToolPanel.tsx) — cancelling at Google redirects back to the canvas with `?error=access_denied`, but the AuthModal that initiated sign-in is unmounted after the reload, so the error was never shown and the param lingered. An always-mounted effect in ToolPanel now reopens the AuthModal (GoogleSignInButton shows "Sign-in was cancelled." and scrubs the param), or just scrubs a stale param if the user is actually signed in.
3. **Library footer factually wrong** — `getUserSessions` is owned-only since PR #66, so "recent collaborations" never appear. Footer now reads "Shows paintings you own."
4. **restoreSession existence leak** (convex/paintingSessions.ts) — non-owners got a distinguishing throw while missing ids got `"not_found"`, letting any authed user probe whether a session exists. Non-owners now get `"not_found"` too, matching what `getSession` hides.

### Minor

5. **Online-count mismatch** — the presence pill and SessionInfo card computed counts differently (SessionInfo used raw `presence.length + 1`, double-counting self and stale rows). Extracted `activeCollaborators()` from PresenceStrip and both now use it, so the counts agree by construction.
6. **A11y regressions from the rebuilt AI modal** — close buttons on AIGenerationModal, BackgroundRemovalModal, and MergeTwoModal are now 40×40px with `aria-label="Close modal"`; `text-white/50` slider captions and thumbnail hint lifted to `/70`; `text-white/40` body text in AuthModal, ImageUploadModal, and the login page lifted to `/70`.
7. **Back button exited the app after opening a session from the Library** — `switchToSession` now uses `pushState` for concrete sessions (still `replaceState` for the null/new-canvas case), plus a `popstate` listener that follows `?session=` entries. Verified live: Back stays in the app, Forward re-applies the session.
8. **Structural session-switch reset** — `<KonvaCanvas key={validSessionId}>` so `pendingStrokes`/`imageMasks`/`konvaImages` reset via remount by contract rather than relying on the query-loading gap.
9. **Overlapping rename hit-targets** (LibraryModal) — `gap-2` + `p-3 -m-2` made ✗ overlap ✓ and ✓ overlay the input's right edge. Now `gap-3` + `-m-1.5`: negative margins (6+6=12px) exactly equal the gap, zero overlap.
10. **Recent-generations strip shrank after moderation failures** (convex/aiGeneration.ts) — `getSessionGenerations` took 10 then filtered. Now takes 50, filters (completed + Convex-storage URLs only, dropping expired Replicate fallback URLs that render as broken thumbnails), then slices to 10.

## Verification

- `pnpm typecheck` passes; `pnpm lint` 0 errors (only pre-existing warnings)
- Verified live in `pnpm dev` against a local backend: redirect sanitizer rejection, OAuth-cancel modal + param scrub, matching online counts, AI modal contrast/labels/close-button size (DOM-audited: no `/40` or `/50` text remains in the modal), Library footer, and Back/Forward across a session switch
- Not exercised live (need a second signed-in account): item 4's non-owner path and item 9's visual check — both are trivial, typechecked changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)