### PR TITLE
Fix sync-banner recovery paths: persist replay queue, honest probes, poison-pill handling

### DIFF
--- a/src/components/KonvaCanvas.tsx
+++ b/src/components/KonvaCanvas.tsx
@@ -267,6 +267,30 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
   const autoFittedRef = useRef<Set<string>>(new Set())
   // Map to track pending strokes by their temporary IDs to backend IDs
   const pendingStrokeIdsRef = useRef<Map<string, Id<"strokes"> | null>>(new Map())
+  // Latest backend stroke ids, kept for resolvePendingStroke's race check
+  const confirmedStrokeIdsRef = useRef<Set<string>>(new Set())
+  // Called when addStrokeToSession settles — possibly much later, after a
+  // failed stroke has been queued and replayed. A backend id links the
+  // optimistic stroke so the confirmation effect can clear it once the real
+  // stroke arrives; undefined means the stroke was permanently dropped
+  // (poison pill / clear-canvas discard), so remove the optimistic copy
+  // instead of letting it render forever.
+  const resolvePendingStroke = useCallback((tempId: string, strokeId: Id<"strokes"> | undefined) => {
+    if (strokeId && !confirmedStrokeIdsRef.current.has(strokeId)) {
+      pendingStrokeIdsRef.current.set(tempId, strokeId)
+    } else {
+      // Either dropped, or the backend stroke already arrived via the query
+      // before this mapping landed (the confirmation effect can no longer
+      // match it) — clear the optimistic copy now.
+      pendingStrokeIdsRef.current.delete(tempId)
+      setPendingStrokes(prev => {
+        if (!prev.has(tempId)) return prev
+        const map = new Map(prev)
+        map.delete(tempId)
+        return map
+      })
+    }
+  }, [])
   // Cursor position for brush size indicator
   const [cursorPosition, setCursorPosition] = useState<Point | null>(null)
   // Track if mouse is over the canvas stage (via shared context)
@@ -469,11 +493,12 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
 
   // Remove confirmed strokes from pending when they appear in the strokes array
   useEffect(() => {
+    confirmedStrokeIdsRef.current = new Set(strokes.map(s => s._id))
     if (strokes.length > 0) {
       setPendingStrokes(prev => {
         const newPending = new Map(prev)
-        const strokeIds = new Set(strokes.map(s => s._id))
-        
+        const strokeIds = confirmedStrokeIdsRef.current
+
         // Check each pending stroke to see if it's been confirmed
         for (const [tempId, pendingStroke] of newPending) {
           const backendId = pendingStrokeIdsRef.current.get(tempId)
@@ -773,9 +798,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
         pendingStrokeIdsRef.current.set(tempId, null)
         const layerIdToUse = activeLayerId || null
         addStrokeToSession(finalStrokePoints, '#000000', size, 1, true, layerIdToUse, 'solid').then(strokeId => {
-          if (strokeId) {
-            pendingStrokeIdsRef.current.set(tempId, strokeId)
-          }
+          resolvePendingStroke(tempId, strokeId)
         }).catch(err => {
           console.error('[KonvaCanvas] Error saving eraser stroke on image layer:', err)
         })
@@ -830,9 +853,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
         console.log('[KonvaCanvas] Saving stroke with layerId:', layerIdToUse, 'isEraser:', selectedTool === 'eraser', 'activeLayerId:', activeLayerId, 'activePaintLayerId:', activePaintLayerId, 'activeLayer:', activeLayer)
         addStrokeToSession(finalStrokePoints, color, size, opacity, selectedTool === 'eraser', layerIdToUse, selectedTool === 'eraser' ? 'solid' : colorMode).then(strokeId => {
           console.log('[KonvaCanvas] Stroke saved with ID:', strokeId)
-          if (strokeId) {
-            pendingStrokeIdsRef.current.set(tempId, strokeId)
-          }
+          resolvePendingStroke(tempId, strokeId)
         }).catch(err => {
           console.error('[KonvaCanvas] Error saving stroke:', err)
         })
@@ -842,7 +863,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
     setCurrentStroke([])
     setCurrentStrokeId(null)
     onStrokeEnd?.()
-  }, [isDrawing, currentStroke, getPointerPosition, color, size, opacity, addStrokeToSession, onStrokeEnd, selectedTool, activeLayerId, activePaintLayerId, layers])
+  }, [isDrawing, currentStroke, getPointerPosition, color, size, opacity, addStrokeToSession, resolvePendingStroke, onStrokeEnd, selectedTool, activeLayerId, activePaintLayerId, layers])
 
   // Fallback global listener to ensure drawing stops if pointer capture fails
   useEffect(() => {
@@ -876,9 +897,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
           pendingStrokeIdsRef.current.set(tempId, null)
           const layerIdToUse = activeLayerId || null
           addStrokeToSession(currentStroke, '#000000', size, 1, true, layerIdToUse, 'solid').then(strokeId => {
-            if (strokeId) {
-              pendingStrokeIdsRef.current.set(tempId, strokeId)
-            }
+            resolvePendingStroke(tempId, strokeId)
           })
         } else {
           // Normal paint layer behavior
@@ -928,9 +947,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
           })
 
           addStrokeToSession(currentStroke, color, size, opacity, selectedTool === 'eraser', layerIdToUse, selectedTool === 'eraser' ? 'solid' : colorMode).then(strokeId => {
-            if (strokeId) {
-              pendingStrokeIdsRef.current.set(tempId, strokeId)
-            }
+            resolvePendingStroke(tempId, strokeId)
           })
         }
       }
@@ -942,7 +959,7 @@ const KonvaCanvasComponent = (props: KonvaCanvasProps, ref: React.Ref<CanvasRef>
 
     document.addEventListener('pointerup', handleGlobalPointerUp)
     return () => document.removeEventListener('pointerup', handleGlobalPointerUp)
-  }, [isDrawing, currentStroke, color, size, opacity, addStrokeToSession, onStrokeEnd, selectedTool, activeLayerId, activePaintLayerId, layers])
+  }, [isDrawing, currentStroke, color, size, opacity, addStrokeToSession, resolvePendingStroke, onStrokeEnd, selectedTool, activeLayerId, activePaintLayerId, layers])
 
   // Handle pointer leave - hide cursor  
   const handlePointerLeave = useCallback(() => {

--- a/src/components/PaintingView.tsx
+++ b/src/components/PaintingView.tsx
@@ -7,6 +7,7 @@ import { AdminPanel } from './AdminPanel' // Import AdminPanel
 import { SessionInfo } from './SessionInfo'
 import { PresenceStrip } from './PresenceStrip'
 import { SyncStatusBanner } from './SyncStatusBanner'
+import { discardPendingStrokes } from '../lib/syncStatus'
 import { P2PStatus } from './P2PStatus'
 import { P2PDebugPanel } from './P2PDebugPanel'
 import { ImageUploadModal } from './ImageUploadModal'
@@ -570,22 +571,18 @@ export function PaintingView() {
     }
     
     try {
-      await undoLastStroke()
-      // Success - the stroke will be removed from rawStrokes automatically
-      // If we were relying solely on local flag before server queries caught up, clear it now
-      if (hasLocalStrokes && (!rawStrokes || rawStrokes.length <= 1)) {
-        setHasLocalStrokes(false)
+      // undoLastStroke never throws — it reports failures to the sync banner
+      // and returns false — so check the return value instead of catching.
+      const result = await undoLastStroke()
+      if (result !== false) {
+        // Success - the stroke will be removed from rawStrokes automatically
+        // If we were relying solely on local flag before server queries caught up, clear it now
+        if (hasLocalStrokes && (!rawStrokes || rawStrokes.length <= 1)) {
+          setHasLocalStrokes(false)
+        }
       }
-    } catch (error) {
-      console.error('Failed to undo stroke:', error)
-      // On error, remove from pending set to show the stroke again
-      if (lastStrokeId) {
-        setPendingUndoStrokeIds(prev => {
-          const newSet = new Set(prev)
-          newSet.delete(lastStrokeId)
-          return newSet
-        })
-      }
+      // On failure the finally below removes the stroke from the pending-undo
+      // set, so it shows again.
     } finally {
       releaseMutationLock()
       // Clear pending undo set after operation completes
@@ -626,6 +623,9 @@ export function PaintingView() {
     // Clear local canvas immediately for responsiveness
     canvasRef.current?.clear()
     setHasLocalStrokes(false)
+    // Drop this session's queued failed strokes too — otherwise a
+    // post-recovery replay would resurrect them onto the cleared canvas.
+    if (sessionId) discardPendingStrokes(sessionId)
 
     // Clear the session in the backend
     try {

--- a/src/components/SyncStatusBanner.tsx
+++ b/src/components/SyncStatusBanner.tsx
@@ -3,6 +3,7 @@ import { useConvexAuth } from 'convex/react'
 import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { useAuthState, authClient } from '../lib/auth-client'
 import { useSyncStatus, retrySync } from '../lib/syncStatus'
+import { suppressUnloadGuard, resumeUnloadGuard } from '../lib/unsavedChanges'
 
 /**
  * Grace period before flagging the "Better Auth signed in but Convex not
@@ -35,13 +36,17 @@ export function SyncStatusBanner() {
     return () => clearTimeout(timer)
   }, [desyncCandidate])
 
-  // When Convex auth comes back (e.g. after re-sign-in), replay queued strokes.
+  // When Convex auth comes back (e.g. after re-sign-in), replay queued
+  // strokes. Also retry when the error state appears while already
+  // authenticated — the rehydrated queue flips status asynchronously, so the
+  // auth edge alone can be consumed before the queue is visible.
   const wasAuthenticatedRef = useRef(isAuthenticated)
   useEffect(() => {
-    if (isAuthenticated && !wasAuthenticatedRef.current && sync.status === 'error') {
+    const cameOnline = isAuthenticated && !wasAuthenticatedRef.current
+    wasAuthenticatedRef.current = isAuthenticated
+    if (isAuthenticated && sync.status === 'error' && (cameOnline || sync.pendingStrokeCount > 0)) {
       void retrySync()
     }
-    wasAuthenticatedRef.current = isAuthenticated
   }, [isAuthenticated, sync.status])
 
   if (import.meta.env.VITE_AUTH_DISABLED === 'true') return null
@@ -58,6 +63,10 @@ export function SyncStatusBanner() {
 
   const handleSignInAgain = async () => {
     setSigningIn(true)
+    // Queued strokes are persisted to localStorage (write-through in
+    // syncStatus) and replayed after the round-trip, so this intentional
+    // full-page redirect loses nothing — don't show the "Leave site?" prompt.
+    suppressUnloadGuard()
     try {
       // Round-trip through Google to mint a fresh Convex JWT, then land back
       // on this painting so no work is lost.
@@ -65,10 +74,14 @@ export function SyncStatusBanner() {
         provider: 'google',
         callbackURL: window.location.pathname + window.location.search,
       })
-      if (result.error) setSigningIn(false)
+      if (result.error) {
+        setSigningIn(false)
+        resumeUnloadGuard()
+      }
       // On success the browser navigates away; leave the spinner running.
     } catch {
       setSigningIn(false)
+      resumeUnloadGuard()
     }
   }
 
@@ -89,7 +102,7 @@ export function SyncStatusBanner() {
         )}
       </div>
       <div className="flex shrink-0 items-center gap-2">
-        {isAuthIssue && isSignedIn && (
+        {isAuthIssue && (
           <button
             type="button"
             onClick={handleSignInAgain}
@@ -97,7 +110,9 @@ export function SyncStatusBanner() {
             className="flex items-center gap-1 rounded bg-amber-600 px-2 py-1 text-xs font-medium text-white hover:bg-amber-700 disabled:opacity-60"
           >
             {signingIn && <Loader2 className="h-3 w-3 animate-spin" />}
-            Sign in again
+            {/* Also offered when the session is fully expired (isSignedIn
+                false) — that state previously had no actionable CTA. */}
+            {isSignedIn ? 'Sign in again' : 'Sign in'}
           </button>
         )}
         <button

--- a/src/hooks/usePaintingSession.ts
+++ b/src/hooks/usePaintingSession.ts
@@ -4,7 +4,13 @@ import { Id } from "../../convex/_generated/dataModel";
 import { useCallback, useEffect, useState, useRef, useMemo } from "react";
 import { p2pLogger } from "../lib/p2p-logger";
 import { convexLow } from "../lib/convex";
-import { reportSyncFailure, reportSyncSuccess } from "../lib/syncStatus";
+import {
+  reportSyncFailure,
+  reportSyncSuccess,
+  enqueueStroke,
+  hasPendingStrokes,
+  retrySync,
+} from "../lib/syncStatus";
 import { beginInFlightStroke, endInFlightStroke } from "../lib/unsavedChanges";
 import {
   generateGuestKey,
@@ -238,7 +244,7 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
           sessionId,
           viewerId: currentUser.id,
           lastAckedStrokeOrder: maxStrokeOrder,
-        });
+        }).catch((e) => reportSyncFailure(e));
       }
     }
   }, [strokes, sessionId, currentUser.id, upsertViewerState]);
@@ -298,6 +304,16 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
       guestKey: localGuestKey || undefined,
     };
 
+    // While earlier strokes are queued for replay, route new strokes through
+    // the queue too — sending them directly would save them ahead of the
+    // queued ones, inverting stroke order (and making undo hit the wrong
+    // stroke). The returned promise resolves with the backend id on replay.
+    if (hasPendingStrokes()) {
+      const replayPromise = enqueueStroke(strokeArgs);
+      void retrySync();
+      return replayPromise;
+    }
+
     beginInFlightStroke();
     try {
       const strokeId = await addStroke(strokeArgs);
@@ -305,10 +321,11 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
       return strokeId;
     } catch (e) {
       // Queue the stroke for replay after re-auth/reconnect and surface the
-      // failure via the sync banner instead of failing silently.
+      // failure via the sync banner instead of failing silently. The replay
+      // promise resolves with the eventual backend id (or undefined if the
+      // stroke is dropped) so the canvas can reconcile its optimistic copy.
       console.error('[usePaintingSession] Failed to save stroke:', e);
-      reportSyncFailure(e, strokeArgs);
-      return undefined;
+      return reportSyncFailure(e, strokeArgs);
     } finally {
       endInFlightStroke();
     }
@@ -363,7 +380,9 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
       if (pendingPresenceRef.current === payload) {
         pendingPresenceRef.current = null;
       }
-      reportSyncSuccess();
+      // updatePresence is unauthenticated, so this success can't clear an
+      // auth-kind error — reportSyncSuccess gates on the source.
+      reportSyncSuccess("presence");
     } catch (e) {
       // Presence is best-effort, but a failure here is the same auth/network
       // problem that breaks stroke saving — surface it via the sync banner.
@@ -423,10 +442,17 @@ export function usePaintingSession(sessionId: Id<"paintingSessions"> | null) {
     if (!sessionId) return;
     
     // Clear both completed strokes and live strokes
-    await Promise.all([
-      clearSessionMutation({ sessionId, guestKey: localGuestKey || undefined }),
-      clearSessionLiveStrokes({ sessionId, guestKey: localGuestKey || undefined })
-    ]);
+    try {
+      await Promise.all([
+        clearSessionMutation({ sessionId, guestKey: localGuestKey || undefined }),
+        clearSessionLiveStrokes({ sessionId, guestKey: localGuestKey || undefined })
+      ]);
+    } catch (e) {
+      // Surface via the sync banner instead of failing silently, then rethrow
+      // so the caller's own error handling still runs.
+      reportSyncFailure(e);
+      throw e;
+    }
     
     // Reset local acknowledgment state
     localLastAckedStrokeOrderRef.current = 0;

--- a/src/lib/syncStatus.ts
+++ b/src/lib/syncStatus.ts
@@ -1,5 +1,5 @@
 import { useSyncExternalStore } from "react";
-import type { FunctionArgs } from "convex/server";
+import type { FunctionArgs, FunctionReturnType } from "convex/server";
 import { api } from "../../convex/_generated/api";
 import { convexHigh } from "./convex";
 import { registerUnsavedWorkCounter } from "./unsavedChanges";
@@ -12,6 +12,9 @@ import { registerUnsavedWorkCounter } from "./unsavedChanges";
  * mid-session, which makes the backend throw "Unauthorized" — the failure is
  * reported here instead of vanishing in an unhandled promise rejection. Failed
  * strokes are retained so a successful re-auth can replay them.
+ *
+ * The queue is written through to localStorage so it survives the full-page
+ * OAuth redirect that "Sign in again" performs (and accidental reloads).
  */
 
 export type SyncErrorKind = "auth" | "network" | "unknown";
@@ -25,27 +28,116 @@ export interface SyncStatus {
 }
 
 type AddStrokeArgs = FunctionArgs<typeof api.strokes.addStroke>;
+type StrokeId = FunctionReturnType<typeof api.strokes.addStroke>;
+
+interface PendingStroke {
+  args: AddStrokeArgs;
+  /**
+   * Resolves with the backend stroke id once the stroke is replayed (so the
+   * canvas can reconcile its optimistic copy), or with undefined if the
+   * stroke is dropped/discarded. Absent for strokes rehydrated after a page
+   * load — the optimistic canvas state is gone by then anyway.
+   */
+  resolve?: (id: StrokeId | undefined) => void;
+}
 
 // Cap the replay queue so a long offline stretch can't grow memory unboundedly.
 const MAX_PENDING_STROKES = 100;
+// Drop a queued stroke after this many replay failures that aren't explained
+// by an auth/network outage — it's a poison pill (e.g. deleted layerId) that
+// would otherwise jam the queue forever.
+const MAX_POISON_RETRIES = 3;
+const STORAGE_KEY = "wepaintai:pendingStrokes:v1";
+// Rehydrated queues older than this are stale enough to discard.
+const STORAGE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
-let pendingStrokes: AddStrokeArgs[] = [];
+let pendingStrokes: PendingStroke[] = [];
 let state: SyncStatus = {
   status: "ok",
   kind: "unknown",
   pendingStrokeCount: 0,
   retrying: false,
 };
+// Consecutive unexplained replay failures for the current queue head.
+let headFailureCount = 0;
 
 const listeners = new Set<() => void>();
 
-// Strokes queued for replay are unsaved work — closing the tab would lose them.
+// Strokes queued for replay are unsaved work — closing the tab would lose
+// them (they're persisted, but only replayed if the user comes back).
 registerUnsavedWorkCounter(() => pendingStrokes.length);
 
 function setState(partial: Partial<SyncStatus>) {
   state = { ...state, ...partial, pendingStrokeCount: pendingStrokes.length };
   listeners.forEach((l) => l());
 }
+
+/** Write-through persistence so the queue survives redirects and reloads. */
+function persistQueue() {
+  if (typeof window === "undefined") return;
+  try {
+    if (pendingStrokes.length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          savedAt: Date.now(),
+          kind: state.kind,
+          strokes: pendingStrokes.map((p) => p.args),
+        })
+      );
+    }
+  } catch {
+    // Quota exceeded / private mode — the in-memory queue still works.
+  }
+}
+
+/** Restore a queue persisted before a sign-in redirect or reload. */
+function rehydrateQueue() {
+  if (typeof window === "undefined") return;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as {
+      savedAt?: number;
+      kind?: SyncErrorKind;
+      strokes?: AddStrokeArgs[];
+    };
+    if (
+      !Array.isArray(parsed.strokes) ||
+      parsed.strokes.length === 0 ||
+      (typeof parsed.savedAt === "number" &&
+        Date.now() - parsed.savedAt > STORAGE_MAX_AGE_MS)
+    ) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    pendingStrokes = parsed.strokes.slice(-MAX_PENDING_STROKES).map((args) => ({ args }));
+    // Surface the banner so the user sees the queue; replay kicks off once
+    // auth comes back (SyncStatusBanner effect) or any mutation succeeds.
+    // Applied async so the first hydration render still matches the server
+    // HTML (which never shows the banner).
+    const kind = parsed.kind === "auth" || parsed.kind === "network" ? parsed.kind : "unknown";
+    setTimeout(() => {
+      if (pendingStrokes.length > 0 && state.status === "ok") {
+        setState({ status: "error", kind });
+        // Kick a replay immediately: guests (and already-valid sessions)
+        // recover silently; if auth isn't ready yet this fails and the
+        // SyncStatusBanner effect retries once Convex authenticates.
+        void retrySync();
+      }
+    }, 0);
+  } catch {
+    // Corrupt entry — drop it rather than fail on every load.
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+rehydrateQueue();
 
 /**
  * Distinguish auth failures from transient network errors. Backend auth
@@ -67,26 +159,68 @@ export function classifySyncError(error: unknown): SyncErrorKind {
   return "unknown";
 }
 
-/** Record a failed mutation; optionally retain the stroke args for replay. */
-export function reportSyncFailure(error: unknown, failedStroke?: AddStrokeArgs) {
-  if (failedStroke) {
-    pendingStrokes.push(failedStroke);
+/**
+ * Errors that will fail identically on every replay (bad arguments, e.g. a
+ * layerId that no longer validates) — retrying them is pointless.
+ */
+function isNonRetryableError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /ArgumentValidationError|Validation failed/i.test(message);
+}
+
+/** True while failed strokes are queued for replay. */
+export function hasPendingStrokes(): boolean {
+  return pendingStrokes.length > 0;
+}
+
+/**
+ * Queue a stroke for replay. Returns a promise that resolves with the backend
+ * stroke id once the stroke is successfully replayed, or undefined if it is
+ * dropped (poison pill, queue overflow, or discard).
+ */
+export function enqueueStroke(args: AddStrokeArgs): Promise<StrokeId | undefined> {
+  return new Promise((resolve) => {
+    pendingStrokes.push({ args, resolve });
     if (pendingStrokes.length > MAX_PENDING_STROKES) {
-      pendingStrokes = pendingStrokes.slice(-MAX_PENDING_STROKES);
+      const dropped = pendingStrokes.splice(0, pendingStrokes.length - MAX_PENDING_STROKES);
+      headFailureCount = 0;
+      dropped.forEach((d) => d.resolve?.(undefined));
     }
-  }
+    persistQueue();
+    setState({});
+  });
+}
+
+/**
+ * Record a failed mutation; optionally retain the stroke args for replay.
+ * When a stroke is provided, returns a promise that resolves with its backend
+ * id after replay (or undefined if the stroke is eventually dropped).
+ */
+export function reportSyncFailure(
+  error: unknown,
+  failedStroke?: AddStrokeArgs
+): Promise<StrokeId | undefined> | undefined {
   const kind = classifySyncError(error);
-  // Don't let a later vague error mask a known auth failure.
-  const nextKind = state.status === "error" && state.kind === "auth" && kind === "unknown" ? "auth" : kind;
+  // Don't let a later vaguer error (e.g. a presence network blip) mask a
+  // known auth failure — only a fresh auth classification keeps kind "auth".
+  const nextKind = state.status === "error" && state.kind === "auth" ? "auth" : kind;
+  // Set the kind before enqueueing so persistQueue stores the right one.
   setState({ status: "error", kind: nextKind });
+  return failedStroke ? enqueueStroke(failedStroke) : undefined;
 }
 
 /**
  * Record a successful mutation. Clears the error banner and, if strokes are
  * still queued from the outage, kicks off a replay.
+ *
+ * `source` matters for auth errors: updatePresence has no auth check, so its
+ * 20s heartbeat succeeding proves nothing about an expired JWT — presence
+ * successes must not clear an auth-kind error (or the banner would falsely
+ * clear within ~20s while stroke saving is still broken).
  */
-export function reportSyncSuccess() {
+export function reportSyncSuccess(source: "stroke" | "presence" = "stroke") {
   if (state.status === "ok" && pendingStrokes.length === 0) return;
+  if (source === "presence" && state.status === "error" && state.kind === "auth") return;
   if (pendingStrokes.length > 0) {
     void retrySync();
   } else {
@@ -102,16 +236,58 @@ export function reportSyncSuccess() {
 export async function retrySync(): Promise<boolean> {
   if (state.retrying) return false;
   setState({ retrying: true });
+  let replayedAny = false;
   try {
     while (pendingStrokes.length > 0) {
-      const stroke = pendingStrokes[0];
-      await convexHigh.mutation(api.strokes.addStroke, stroke);
-      pendingStrokes.shift();
-      setState({});
+      const entry = pendingStrokes[0];
+      // Remove by identity, not shift(): a concurrent enqueueStroke overflow
+      // can splice the head while its mutation is in flight, and a blind
+      // shift() would then silently drop a different stroke.
+      const removeEntry = () => {
+        const idx = pendingStrokes.indexOf(entry);
+        if (idx !== -1) pendingStrokes.splice(idx, 1);
+        headFailureCount = 0;
+        persistQueue();
+      };
+      try {
+        const strokeId = await convexHigh.mutation(api.strokes.addStroke, entry.args);
+        removeEntry();
+        replayedAny = true;
+        entry.resolve?.(strokeId);
+        setState({});
+      } catch (error) {
+        const kind = classifySyncError(error);
+        const poison =
+          isNonRetryableError(error) ||
+          (kind === "unknown" && ++headFailureCount >= MAX_POISON_RETRIES);
+        if (poison) {
+          // Drop it so one permanently-failing stroke can't jam the queue —
+          // every later stroke would otherwise be stuck behind it forever.
+          console.error("[syncStatus] Dropping unreplayable stroke:", error);
+          removeEntry();
+          entry.resolve?.(undefined);
+          setState({});
+          continue;
+        }
+        // Auth/network outage (or a transient unknown): keep the stroke and
+        // stop — later strokes must wait so ordering is preserved. A known
+        // auth failure isn't downgraded by a vaguer replay error.
+        setState({
+          status: "error",
+          kind: state.status === "error" && state.kind === "auth" ? "auth" : kind,
+        });
+        persistQueue(); // write the refined kind through for rehydration
+        return false;
+      }
     }
-    if (state.status === "error") {
+    if (state.status === "error" && !replayedAny) {
       // Nothing queued to prove the connection works — probe with a query.
-      await convexHigh.query(api.auth.getCurrentUser, {});
+      // getCurrentUser returns null (rather than throwing) when the JWT is
+      // invalid, so for auth errors a null result means still broken.
+      const user = await convexHigh.query(api.auth.getCurrentUser, {});
+      if (state.kind === "auth" && user === null) {
+        return false;
+      }
     }
     setState({ status: "ok" });
     return true;
@@ -123,9 +299,23 @@ export async function retrySync(): Promise<boolean> {
   }
 }
 
-/** Drop queued strokes (e.g. when the user clears the canvas). */
-export function discardPendingStrokes() {
-  pendingStrokes = [];
+/**
+ * Drop queued strokes (e.g. when the user clears the canvas, so a later
+ * replay doesn't resurrect strokes onto the freshly cleared session). With a
+ * sessionId, only that session's strokes are dropped.
+ */
+export function discardPendingStrokes(sessionId?: string) {
+  const kept: PendingStroke[] = [];
+  for (const entry of pendingStrokes) {
+    if (sessionId && entry.args.sessionId !== sessionId) {
+      kept.push(entry);
+    } else {
+      entry.resolve?.(undefined);
+    }
+  }
+  pendingStrokes = kept;
+  headFailureCount = 0;
+  persistQueue();
   setState({});
 }
 

--- a/src/lib/unsavedChanges.ts
+++ b/src/lib/unsavedChanges.ts
@@ -34,13 +34,28 @@ function hasUnsavedWork(): boolean {
 }
 
 let installed = false;
+let suppressed = false;
+
+/**
+ * Skip the "Leave site?" prompt for an intentional navigation that doesn't
+ * lose work — e.g. the sign-in redirect, where queued strokes are persisted
+ * to localStorage and replayed after the round-trip.
+ */
+export function suppressUnloadGuard() {
+  suppressed = true;
+}
+
+/** Re-enable the prompt (e.g. when the sign-in redirect fails). */
+export function resumeUnloadGuard() {
+  suppressed = false;
+}
 
 /** Idempotent; safe to call from any component effect (client only). */
 export function installUnloadGuard() {
   if (installed || typeof window === "undefined") return;
   installed = true;
   window.addEventListener("beforeunload", (e) => {
-    if (!hasUnsavedWork()) return;
+    if (suppressed || !hasUnsavedWork()) return;
     e.preventDefault();
     // Required by some browsers to actually show the prompt
     e.returnValue = "";


### PR DESCRIPTION
Follow-up to #62 ("surface silent save failures with a sync banner and stroke replay"). The banner UI shipped, but post-merge review found the recovery paths didn't hold up — most critically, the primary CTA destroyed the data it promised to save.

## Critical
- **"Sign in again" no longer loses queued strokes.** The replay queue was a module-level in-memory array, wiped by the full-page OAuth redirect. It's now written through to `localStorage` on every change and rehydrated on load (24h staleness cutoff, hydration-safe state flip that also kicks an immediate replay). The `beforeunload` "Leave site?" prompt is suppressed for this intentional redirect (re-enabled if sign-in fails) — the queue survives the round-trip, so nothing is lost.

## Major
- **Banner can't falsely clear during an auth outage.** `updatePresence` has no auth check, so its 20s heartbeat used to clear the banner within ~20s while stroke saving was still broken. Presence successes are now source-tagged and never clear an `auth`-kind error.
- **Retry gives honest feedback.** The probe used `getCurrentUser`, which returns `null` (doesn't throw) when unauthenticated — Retry reported "fixed" while nothing was. A `null` result with an `auth`-kind error now keeps the banner up; a successfully replayed stroke (which enforces access server-side) is accepted as real proof.
- **Poison pills can't jam the queue.** Replay drops a stroke immediately on `ArgumentValidationError`, or after 3 consecutive failures not explained by an auth/network outage — one permanently-bad stroke (e.g. deleted layerId) no longer blocks every stroke behind it forever.
- **No more double-render/leak after replay.** Failed strokes resolve a deferred promise with the eventual backend id, which feeds back into KonvaCanvas's `pendingStrokeIdsRef` so the confirmation path clears the optimistic copy (with a race guard for the query arriving first). Dropped strokes remove their optimistic copy instead of rendering forever.
- **Clear-canvas discards the queue** (session-scoped), so a post-recovery replay can't resurrect strokes onto the freshly cleared session.

## Minor
- New strokes route through a non-empty queue, preserving stroke order (and undo targets) during an outage.
- `handleUndo` checks `undoLastStroke()`'s return value (it never throws; the old catch was unreachable) — `hasLocalStrokes` no longer resets on failed undo.
- Auth banner shows a "Sign in" CTA even when the session is fully expired (`isSignedIn` false), which previously had no actionable button.
- `clearSession` and `upsertViewerState` failures now report to the banner instead of failing silently.
- A known `auth` error kind is never downgraded by a later vaguer/network error.

## Review notes
- An independent review pass (codex) over the replay state machine surfaced three races that are fixed here: identity-based queue removal (a concurrent overflow could make `shift()` drop the wrong stroke), persisting the error kind only after classification, and the rehydrate-vs-auth-edge retry gap in the banner effect.
- **Accepted limitation:** a stroke submitted while an earlier direct mutation is still in flight can land before that stroke's replay — only when the earlier one fails while the later succeeds; Convex's ordered same-client execution makes this rare.

## Verification
Exercised end-to-end against a local Convex backend with `addStroke` forced to throw "Unauthorized" (expired-JWT simulation), as a guest:
- Strokes queued; banner showed "N strokes waiting to sync", kind `auth`, queue persisted to localStorage.
- Page reload (redirect-teardown equivalent): queue rehydrated, banner reappeared immediately.
- Backend restored + Retry: queue drained FIFO (verified `strokeOrder` in DB, exactly one row per stroke), banner and storage cleared, each stroke rendered once — no double-darkening.
- Clear-canvas with queued strokes: queue/storage emptied; banner correctly stayed until saving actually worked again.
- `pnpm typecheck` clean; `pnpm lint` adds no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)